### PR TITLE
feat: enable exposed server request auth

### DIFF
--- a/action_server/.vscode/launch.json
+++ b/action_server/.vscode/launch.json
@@ -9,7 +9,7 @@
       "type": "python",
       "request": "launch",
       "program": "src/robocorp/action_server/__main__.py",
-      "args": ["start", "--port", "8080", "--expose", "--api-key", "local"],
+      "args": ["start", "--port", "8080", "--expose"],
       "console": "integratedTerminal",
       "justMyCode": true
     }

--- a/action_server/.vscode/launch.json
+++ b/action_server/.vscode/launch.json
@@ -9,7 +9,7 @@
       "type": "python",
       "request": "launch",
       "program": "src/robocorp/action_server/__main__.py",
-      "args": ["start", "--port", "8080", "--expose"],
+      "args": ["start", "--port", "8080", "--expose", "--api-key", "local"],
       "console": "integratedTerminal",
       "justMyCode": true
     }

--- a/action_server/src/robocorp/action_server/_robo_utils/auth.py
+++ b/action_server/src/robocorp/action_server/_robo_utils/auth.py
@@ -1,0 +1,5 @@
+import secrets
+
+
+def generate_api_key():
+    return secrets.token_urlsafe(32)

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -21,7 +21,7 @@ def _name_to_url(name):
     return name.replace("_", "-")
 
 
-def start_server(expose: bool) -> None:
+def start_server(expose: bool, api_key: str | None = None) -> None:
     import docstring_parser
     import uvicorn
     from fastapi.staticfiles import StaticFiles
@@ -142,6 +142,7 @@ def start_server(expose: bool) -> None:
                 "" if not settings.verbose else "v",
                 host,
                 settings.expose_url,
+                str(api_key),
             ]
         )
 

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -96,9 +96,9 @@ async def expose_server(
 
                         try:
                             payload = BodyPayload(**data)
-                            if api_key is not None:
+                            if payload.path != "/openapi.json" and api_key is not None:
                                 if (
-                                    payload.headers.get("Authorization")
+                                    payload.headers.get("authorization")
                                     != f"Bearer {api_key}"
                                 ):
                                     log.error(

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -23,7 +23,7 @@ class BodyPayload(BaseModel):
     path: str
     method: str = "GET"
     body: dict | None = None
-    headers: dict | None = None
+    headers: dict
 
 
 def forward_request(base_url: str, payload: BodyPayload) -> requests.Response:

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -81,6 +81,10 @@ async def expose_server(
                             log.info(
                                 f"🌍 URL: https://{session_payload.sessionId}.{expose_url}"
                             )
+                            if api_key is not None:
+                                log.info(
+                                    f'🔑 Use {{ "Authorization": "Bearer {api_key}" }} to authorize api requests'
+                                )
                             continue
                         except Exception:
                             if not session_payload:

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -112,6 +112,7 @@ async def expose_server(
                                                         },
                                                     }
                                                 ),
+                                                "status": 403,
                                             }
                                         )
                                     )
@@ -129,6 +130,7 @@ async def expose_server(
                                             response.json(),
                                             indent=2,
                                         ),
+                                        "status": response.status_code,
                                     }
                                 )
                             )

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from typing import Optional, Union
 
+from robocorp.action_server._robo_utils.auth import generate_api_key
+
 from . import __version__
 from ._settings import Settings, get_settings
 
@@ -101,8 +103,9 @@ def _create_parser():
     start_parser.add_argument(
         "--api-key",
         dest="api_key",
-        help="""Adds authentication. Pass it as `{"Authorization": "Bearer <secret>"}` header""",
-        default=None,
+        help="""Adds authentication. Pass it as `{"Authorization": "Bearer <secret>"}` header. 
+        Pass `--api-key None` to disable authentication.""",
+        default=generate_api_key(),
     )
     _add_data_args(start_parser, defaults)
     _add_verbose_args(start_parser, defaults)
@@ -303,8 +306,6 @@ To migrate the database to the current version
             elif command == "start":
                 with use_runs_state_ctx(db):
                     from ._server import start_server
-
-                    print("args", base_args.api_key)
 
                     settings.artifacts_dir.mkdir(parents=True, exist_ok=True)
                     start_server(expose=base_args.expose, api_key=base_args.api_key)

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -103,7 +103,7 @@ def _create_parser():
     start_parser.add_argument(
         "--api-key",
         dest="api_key",
-        help="""Adds authentication. Pass it as `{"Authorization": "Bearer <secret>"}` header. 
+        help="""Adds authentication. Pass it as `{"Authorization": "Bearer <API_KEY>"}` header. 
         Pass `--api-key None` to disable authentication.""",
         default=generate_api_key(),
     )

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -98,6 +98,12 @@ def _create_parser():
         action="store_true",
         help="Expose the server to the world",
     )
+    start_parser.add_argument(
+        "--api-key",
+        dest="api_key",
+        help="""Adds authentication. Pass it as `{"Authorization": "Bearer <secret>"}` header""",
+        default=None,
+    )
     _add_data_args(start_parser, defaults)
     _add_verbose_args(start_parser, defaults)
 
@@ -298,8 +304,10 @@ To migrate the database to the current version
                 with use_runs_state_ctx(db):
                     from ._server import start_server
 
+                    print("args", base_args.api_key)
+
                     settings.artifacts_dir.mkdir(parents=True, exist_ok=True)
-                    start_server(expose=base_args.expose)
+                    start_server(expose=base_args.expose, api_key=base_args.api_key)
                     return 0
 
             else:


### PR DESCRIPTION
Added new sub-command for `start` to enforce api key authorization

```
  --api-key API_KEY     Adds authentication. Pass it as `{"Authorization": "Bearer <API_KEY>"}`
                        header. Pass `--api-key None` to disable authentication.
```

- Enabled by default. Server will generate an api key if there's no `--api-key` option passed to the `start` command
- Disable api key authorization by passing `--api-key None`
- Made `/openapi.json` path public as the ChatGPT GPTs doesn't use the authorization headers when importing the spec