### PR TITLE
feat: add `--expose-session` to restart server and get the same expose URL

### DIFF
--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -21,7 +21,9 @@ def _name_to_url(name):
     return name.replace("_", "-")
 
 
-def start_server(expose: bool, api_key: str | None = None) -> None:
+def start_server(
+    expose: bool, api_key: str | None = None, expose_session: str | None = None
+) -> None:
     import docstring_parser
     import uvicorn
     from fastapi.staticfiles import StaticFiles
@@ -143,6 +145,7 @@ def start_server(expose: bool, api_key: str | None = None) -> None:
                 host,
                 settings.expose_url,
                 str(api_key),
+                str(expose_session),
             ]
         )
 

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -74,7 +74,6 @@ async def expose_server(
         session_payload: Optional[SessionPayload] = (
             get_expose_session_payload(expose_session) if expose_session else None
         )
-        print(session_payload)
         while retries < max_retries:
             try:
                 headers = (
@@ -108,7 +107,7 @@ async def expose_server(
                                 )
                             new_expose_session = get_expose_session(session_payload)
                             log.info(
-                                f"🔄 Add following argument to restart with same expose URL: --expose-session {new_expose_session} " # noqa
+                                f"🔄 Add following argument to restart with same expose URL: --expose-session {new_expose_session}  " # noqa
                             )
                             continue
                         except Exception:

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -107,7 +107,7 @@ async def expose_server(
                                 )
                             new_expose_session = get_expose_session(session_payload)
                             log.info(
-                                f"🔄 Add following argument to restart with same expose URL: --expose-session {new_expose_session}  " # noqa
+                                f"🔄 Add following argument to restart with same expose URL: --expose-session {new_expose_session}  "  # noqa
                             )
                             continue
                         except Exception:

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import sys
+import codecs
 from typing import Optional
 
 import requests
@@ -26,6 +27,19 @@ class BodyPayload(BaseModel):
     headers: dict
 
 
+def get_expose_session(payload: SessionPayload) -> str:
+    return f"{payload.sessionId}:{payload.sessionSecret}".encode("ascii").hex()
+
+
+def get_expose_session_payload(expose_session: str) -> SessionPayload:
+    session_id, session_secret = codecs.decode(
+        expose_session.encode("ascii"), "hex"
+    ).split(b":")
+    return SessionPayload(
+        sessionId=session_id.decode(), sessionSecret=session_secret.decode()
+    )
+
+
 def forward_request(base_url: str, payload: BodyPayload) -> requests.Response:
     url = base_url.rstrip("/") + "/" + payload.path.lstrip("/")
 
@@ -42,7 +56,11 @@ def forward_request(base_url: str, payload: BodyPayload) -> requests.Response:
 
 
 async def expose_server(
-    port: int, host: str, expose_url: str, api_key: str | None = None
+    port: int,
+    host: str,
+    expose_url: str,
+    api_key: str | None = None,
+    expose_session: str | None = None,
 ):
     """
     Exposes the server to the world.
@@ -53,7 +71,10 @@ async def expose_server(
         retry_delay = 1
         retries = 0
 
-        session_payload: Optional[SessionPayload] = None
+        session_payload: Optional[SessionPayload] = (
+            get_expose_session_payload(expose_session) if expose_session else None
+        )
+        print(session_payload)
         while retries < max_retries:
             try:
                 headers = (
@@ -83,8 +104,12 @@ async def expose_server(
                             )
                             if api_key is not None:
                                 log.info(
-                                    f'🔑 Use {{ "Authorization": "Bearer {api_key}" }} to authorize api requests'
+                                    f'🔑 Add following header api authorization header to run actions: {{ "Authorization": "Bearer {api_key}" }}'  # noqa
                                 )
+                            new_expose_session = get_expose_session(session_payload)
+                            log.info(
+                                f"🔄 Add following argument to restart with same expose URL: --expose-session {new_expose_session} " # noqa
+                            )
                             continue
                         except Exception:
                             if not session_payload:
@@ -156,7 +181,7 @@ async def expose_server(
 
 
 if __name__ == "__main__":
-    parent_pid, port, verbose, host, expose_url, api_key = sys.argv[1:]
+    parent_pid, port, verbose, host, expose_url, api_key, expose_session = sys.argv[1:]
 
     logging.basicConfig(
         level=logging.DEBUG if verbose.count("v") > 0 else logging.INFO,
@@ -171,5 +196,6 @@ if __name__ == "__main__":
             host=host,
             expose_url=expose_url,
             api_key=api_key if api_key != "None" else None,
+            expose_session=expose_session if expose_session != "None" else None,
         )
     )

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -101,6 +101,12 @@ def _create_parser():
         help="Expose the server to the world",
     )
     start_parser.add_argument(
+        "--expose-session",
+        dest="expose_session",
+        help="Restart action server with existing expose session",
+        default=None,
+    )
+    start_parser.add_argument(
         "--api-key",
         dest="api_key",
         help="""Adds authentication. Pass it as `{"Authorization": "Bearer <API_KEY>"}` header. 
@@ -308,7 +314,11 @@ To migrate the database to the current version
                     from ._server import start_server
 
                     settings.artifacts_dir.mkdir(parents=True, exist_ok=True)
-                    start_server(expose=base_args.expose, api_key=base_args.api_key)
+                    start_server(
+                        expose=base_args.expose,
+                        api_key=base_args.api_key,
+                        expose_session=base_args.expose_session,
+                    )
                     return 0
 
             else:


### PR DESCRIPTION
Prints id that can be passed to `--expose-session` command to get the same expose server URL.
Useful when e.g. using with GPTs.

## Preview

https://github.com/robocorp/robo/assets/1479451/e33ed410-f7eb-4791-ab26-7c901df16d8e

