### PR TITLE
feat: add 'new' command for bootstraping a project

### DIFF
--- a/action_server/src/robocorp/action_server/_new_project.py
+++ b/action_server/src/robocorp/action_server/_new_project.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 def create_new_project():
     try:
-        directory = input("Enter path to create the project: ")
+        directory = input("Name of the project: ")
 
         rcc = get_rcc()
 

--- a/action_server/src/robocorp/action_server/_new_project.py
+++ b/action_server/src/robocorp/action_server/_new_project.py
@@ -1,0 +1,14 @@
+from ._rcc import get_rcc
+
+
+TEMPLATE_URL = "github.com/robocorp/example-action-server-starter"
+
+
+def create_new_project():
+    directory = input("Enter path to create the project: ")
+
+    rcc = get_rcc()
+
+    rcc.pull(url=TEMPLATE_URL, directory=directory)
+
+    print("✅ Project created")

--- a/action_server/src/robocorp/action_server/_new_project.py
+++ b/action_server/src/robocorp/action_server/_new_project.py
@@ -1,14 +1,20 @@
+import logging
 from ._rcc import get_rcc
 
 
 TEMPLATE_URL = "github.com/robocorp/example-action-server-starter"
 
+log = logging.getLogger(__name__)
+
 
 def create_new_project():
-    directory = input("Enter path to create the project: ")
+    try:
+        directory = input("Enter path to create the project: ")
 
-    rcc = get_rcc()
+        rcc = get_rcc()
 
-    rcc.pull(url=TEMPLATE_URL, directory=directory)
+        rcc.pull(url=TEMPLATE_URL, directory=directory)
 
-    print("✅ Project created")
+        log.info("✅ Project created")
+    except KeyboardInterrupt:
+        log.debug("Operation cancelled")

--- a/action_server/src/robocorp/action_server/_rcc.py
+++ b/action_server/src/robocorp/action_server/_rcc.py
@@ -249,6 +249,13 @@ class Rcc(object):
 
         return ActionResult(True, None, EnvInfo(environ))
 
+    def pull(self, url: str, directory: str) -> ActionResult[str]:
+        args = ["pull", url, "--directory", directory]
+        ret = self._run_rcc(args, mutex_name=RCC_CLOUD_ROBOT_MUTEX_NAME)
+        if not ret.success:
+            return ActionResult(False, ret.message, None)
+        return ActionResult(True, None, ret.result)
+
 
 _rcc: Optional["Rcc"] = None
 

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -9,6 +9,7 @@ from robocorp.action_server._robo_utils.auth import generate_api_key
 
 from . import __version__
 from ._settings import Settings, get_settings
+from ._new_project import create_new_project
 
 log = logging.getLogger(__name__)
 
@@ -148,6 +149,14 @@ def _create_parser():
         nargs="?",
     )
 
+    # New project from template
+    new_parser = subparsers.add_parser(
+        "new",
+        help="Bootstrap new project from template",
+    )
+    _add_data_args(new_parser, defaults)
+    _add_verbose_args(new_parser, defaults)
+
     # Schema
     # schema_parser = subparsers.add_parser(
     #     "schema",
@@ -224,6 +233,7 @@ def _main_retcode(args: Optional[list[str]], exit) -> int:
         "migrate",
         "import",
         "start",
+        "new",
     ):
         print(f"Unexpected command: {command}.", file=sys.stderr)
         return 1
@@ -327,6 +337,10 @@ To migrate the database to the current version
                         expose_session=base_args.expose_session,
                     )
                     return 0
+
+            elif command == "new":
+                create_new_project()
+                return 0
 
             else:
                 print(f"Unexpected command: {command}.", file=sys.stderr)

--- a/action_server/tests/action_server_tests/test_cli/test_help.txt
+++ b/action_server/tests/action_server_tests/test_cli/test_help.txt
@@ -1,12 +1,13 @@
-usage: __main__.py [-h] {start,import,download-rcc,version,migrate} ...
+usage: __main__.py [-h] {start,import,download-rcc,new,version,migrate} ...
 
 Robocorp Action Server
 
 positional arguments:
-  {start,import,download-rcc,version,migrate}
+  {start,import,download-rcc,new,version,migrate}
     start               Starts the Robocorp Action Server
     import              Imports an Action Package and exits
     download-rcc        Downloads RCC (by default to the location required by the Robocorp Action Server)
+    new                 Bootstrap new project from template
     version             Prints the version and exits
     migrate             Makes a database migration (if needed) and exits
 


### PR DESCRIPTION
Bootstrap project with `action-server new`

Uses `rcc pull` under the hood. Will bootstrap https://github.com/robocorp/example-action-server-starter

## Preview


https://github.com/robocorp/robo/assets/1479451/34db5fb5-7f89-48b2-9564-3cdb62e3219f

