### PR TITLE
chore: reduce rcc output when running `action-server`

### DIFF
--- a/action_server/src/robocorp/action_server/_actions_import.py
+++ b/action_server/src/robocorp/action_server/_actions_import.py
@@ -120,7 +120,7 @@ Note: no virtual environment will be used for the imported actions, they'll be r
     if not name:
         name = import_path.name
 
-    log.info(f"Python Interpretor path: {use_env.get('RCC_HOLOTREE_SPACE_ROOT')}/bin/python")
+    log.info(f"Python Interpreter path: {use_env.get('RCC_HOLOTREE_SPACE_ROOT')}/bin/python")
 
     action_package = ActionPackage(
         id=action_package_id,

--- a/action_server/src/robocorp/action_server/_actions_import.py
+++ b/action_server/src/robocorp/action_server/_actions_import.py
@@ -120,6 +120,8 @@ Note: no virtual environment will be used for the imported actions, they'll be r
     if not name:
         name = import_path.name
 
+    log.info(f"Python Interpretor path: {use_env.get('RCC_HOLOTREE_SPACE_ROOT')}/bin/python")
+
     action_package = ActionPackage(
         id=action_package_id,
         name=name,

--- a/action_server/src/robocorp/action_server/_actions_import.py
+++ b/action_server/src/robocorp/action_server/_actions_import.py
@@ -120,7 +120,9 @@ Note: no virtual environment will be used for the imported actions, they'll be r
     if not name:
         name = import_path.name
 
-    log.info(f"Python Interpretor path: {use_env.get('RCC_HOLOTREE_SPACE_ROOT')}/bin/python")
+    log.info(
+        f"Python Interpretor path: {use_env.get('RCC_HOLOTREE_SPACE_ROOT')}/bin/python"
+    )
 
     action_package = ActionPackage(
         id=action_package_id,

--- a/action_server/src/robocorp/action_server/_actions_import.py
+++ b/action_server/src/robocorp/action_server/_actions_import.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import platform
 import subprocess
 import typing
 from pathlib import Path
@@ -120,9 +121,12 @@ Note: no virtual environment will be used for the imported actions, they'll be r
     if not name:
         name = import_path.name
 
-    log.info(
-        f"Python Interpretor path: {use_env.get('RCC_HOLOTREE_SPACE_ROOT')}/bin/python"
-    )
+    space_root = use_env.get("RCC_HOLOTREE_SPACE_ROOT")
+    if space_root:
+        if platform.system() == "Windows":
+            log.info(f"Python interpretor path: {Path(space_root) / 'python.exe'}")
+        else:
+            log.info(f"Python interpretor path: {Path(space_root) / 'bin' / 'python'}")
 
     action_package = ActionPackage(
         id=action_package_id,

--- a/action_server/src/robocorp/action_server/_rcc.py
+++ b/action_server/src/robocorp/action_server/_rcc.py
@@ -177,7 +177,7 @@ class Rcc(object):
         output = boutput.decode("utf-8", "replace")
 
         do_log_as_info = (
-            log_errors and logging.root.level <= logging.INFO
+            log_errors and logging.root.level < logging.INFO
         ) or logging.root.level <= logging.DEBUG
 
         if do_log_as_info:
@@ -206,7 +206,7 @@ class Rcc(object):
             mutex_name=RCC_CLOUD_ROBOT_MUTEX_NAME,
             cwd=str(conda_yaml.parent),
             timeout=timeout,  # Creating the env may be really slow!
-            show_interactive_output=True,
+            show_interactive_output=logging.root.level <= logging.DEBUG,
         )
 
         def return_failure(msg: Optional[str]) -> ActionResult[EnvInfo]:


### PR DESCRIPTION
Reduce RCC logs. Show them with `--verbose` option.

Also, print holotree python interpretor path so it can be more easily found for setting up VSCode. Not everyone will want to use Robocorp VSCode extension.

