### PR TITLE
Fix: [Action Server] Hide disabled actions from the action list

### DIFF
--- a/action_server/frontend/src/lib/sampleData.ts
+++ b/action_server/frontend/src/lib/sampleData.ts
@@ -3,6 +3,7 @@ import { Action, ActionPackage, Run } from './types';
 const action1: Action = {
   id: '1',
   action_package_id: 'calc1',
+  enabled: true,
   name: 'Action 1',
   docs: 'Documentation for Action 1',
   file: 'action_1.js',
@@ -14,6 +15,7 @@ const action1: Action = {
 const action2: Action = {
   id: '2',
   action_package_id: 'calc1',
+  enabled: true,
   name: 'Action 2',
   docs: 'Documentation for Action 2',
   file: 'action_2.js',
@@ -25,6 +27,7 @@ const action2: Action = {
 const action3: Action = {
   id: '3',
   action_package_id: 'calc1',
+  enabled: false,
   name: 'Action 3',
   docs: 'Documentation for Action 3',
   file: 'action_3.js',

--- a/action_server/frontend/src/lib/types.ts
+++ b/action_server/frontend/src/lib/types.ts
@@ -9,6 +9,7 @@ export interface Action {
   action_package_id: string; // foreign key to the action package
   name: string; // The action name
   docs: string; // Docs for the action
+  enabled: boolean; // Is the action available to be run
 
   // File for the action (relative to the directory in the ActionPackage).
   file: string;

--- a/action_server/frontend/src/views/actions/components/ActionDetails.tsx
+++ b/action_server/frontend/src/views/actions/components/ActionDetails.tsx
@@ -36,8 +36,8 @@ export const ActionDetails: FC = () => {
             <Drawer.Header.Title title={action.name} />
             <Drawer.Header.Badges>
               {!action.enabled && (
-                <Tooltip text="This action is not available or has been removed">
-                  <Badge variant="info" size="small" label="Disabled" />
+                <Tooltip text="This action has been removed or renamed and is not available for running">
+                  <Badge variant="warning" size="small" label="Not available" />
                 </Tooltip>
               )}
             </Drawer.Header.Badges>

--- a/action_server/frontend/src/views/actions/components/ActionDetails.tsx
+++ b/action_server/frontend/src/views/actions/components/ActionDetails.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Drawer, Tabs } from '@robocorp/components';
+import { Badge, Drawer, Tabs, Tooltip } from '@robocorp/components';
 
 import { useActionServerContext } from '~/lib/actionServerContext';
 import { ActionRun } from './ActionRun';
@@ -34,14 +34,23 @@ export const ActionDetails: FC = () => {
         <>
           <Drawer.Header>
             <Drawer.Header.Title title={action.name} />
+            <Drawer.Header.Badges>
+              {!action.enabled && (
+                <Tooltip text="This action is not available or has been removed">
+                  <Badge variant="info" size="small" label="Disabled" />
+                </Tooltip>
+              )}
+            </Drawer.Header.Badges>
           </Drawer.Header>
           <Drawer.Content>
             <Tabs>
-              <Tabs.Tab>Run</Tabs.Tab>
+              {action.enabled && <Tabs.Tab>Run</Tabs.Tab>}
               <Tabs.Tab>Documentation</Tabs.Tab>
-              <Tabs.Panel>
-                <ActionRun action={action} actionPackage={actionPackage} />
-              </Tabs.Panel>
+              {action.enabled && (
+                <Tabs.Panel>
+                  <ActionRun action={action} actionPackage={actionPackage} />
+                </Tabs.Panel>
+              )}
               <Tabs.Panel>
                 <ActionDocumentation action={action} />
               </Tabs.Panel>

--- a/action_server/frontend/src/views/actions/index.tsx
+++ b/action_server/frontend/src/views/actions/index.tsx
@@ -65,7 +65,9 @@ export const ActionPackages = () => {
   const { loadedActions, loadedRuns } = useActionServerContext();
 
   const actions = useMemo(() => {
-    return loadedActions.data?.flatMap((item) => item.actions) || [];
+    return (
+      loadedActions.data?.flatMap((item) => item.actions).filter((action) => action.enabled) || []
+    );
   }, [loadedActions.data]);
 
   const tableProps = useMemo(() => {


### PR DESCRIPTION
- Hide disabled actions from the action list
- If a disabled action is opened via run history, disable run option for it:

<img width="1242" alt="image" src="https://github.com/robocorp/robocorp/assets/31288628/cc98dd8f-04df-4e9e-9614-25df076470bf">
