### PR TITLE
feat: reuse same api key for restarted expose sessions

### DIFF
--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -31,6 +31,7 @@ class BodyPayload(BaseModel):
 class ExposeSessionJson(BaseModel):
     expose_session: str
     url: str
+    api_key: str | None = None
 
 
 def get_expose_session_path(datadir: str) -> str:
@@ -53,12 +54,14 @@ def read_expose_session_json(datadir: str) -> None | ExposeSessionJson:
     return session_json
 
 
-def write_expose_session_json(datadir: str, expose_session: str, url: str) -> None:
+def write_expose_session_json(
+    datadir: str, expose_session_json=ExposeSessionJson
+) -> None:
     expose_session_path = get_expose_session_path(datadir)
     log.debug(f"🗂️ Writing expose_session.json path={expose_session_path}")
     with open(expose_session_path, "w") as f:
         json.dump(
-            ExposeSessionJson(expose_session=expose_session, url=url).model_dump(),
+            expose_session_json.model_dump(),
             f,
             indent=2,
         )
@@ -145,8 +148,11 @@ async def expose_server(
                             new_expose_session = get_expose_session(session_payload)
                             write_expose_session_json(
                                 datadir=datadir,
-                                expose_session=new_expose_session,
-                                url=url,
+                                expose_session_json=ExposeSessionJson(
+                                    expose_session=new_expose_session,
+                                    api_key=api_key,
+                                    url=url,
+                                ),
                             )
                             continue
                         except Exception as e:

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -127,7 +127,7 @@ def _create_parser():
             'Adds authentication. Pass it as `{"Authorization": "Bearer <API_KEY>"}` '
             "header. Pass `--api-key None` to disable authentication."
         ),
-        default=generate_api_key(),
+        default=None,
     )
     start_parser.add_argument(
         "--actions-sync",
@@ -454,9 +454,17 @@ To migrate the database to the current version
                                     else:
                                         expose_session = None
 
+                            api_key = base_args.api_key
+                            if api_key is None:
+                                # reuse the previously exposed api key
+                                if expose_session and expose_session.api_key:
+                                    api_key = expose_session.api_key
+                                else:
+                                    api_key = generate_api_key()
+
                             start_server(
                                 expose=base_args.expose,
-                                api_key=base_args.api_key,
+                                api_key=api_key,
                                 expose_session=expose_session.expose_session
                                 if expose_session
                                 else None,


### PR DESCRIPTION
Saves `api_key` to `ExposeSessionJson` so we can restart the expose session with the same API key.

Can still be overwritten by passing `--api-key <key>` option.