### PR TITLE
Chore:[Action Server] Improve output logging format

### DIFF
--- a/action_server/poetry.lock
+++ b/action_server/poetry.lock
@@ -912,6 +912,21 @@ snowballstemmer = ">=2.2.0"
 toml = ["tomli (>=1.2.3)"]
 
 [[package]]
+name = "pygments"
+version = "2.17.2"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pygments-2.17.2-py3-none-any.whl", hash = "sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c"},
+    {file = "pygments-2.17.2.tar.gz", hash = "sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"},
+]
+
+[package.extras]
+plugins = ["importlib-metadata"]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pylint"
 version = "2.17.7"
 description = "python code static checker"
@@ -1027,6 +1042,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1034,8 +1050,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1052,6 +1075,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1059,6 +1083,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1099,6 +1124,24 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "rich"
+version = "13.7.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
+    {file = "rich-13.7.0.tar.gz", hash = "sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "robocorp-actions"
@@ -1697,4 +1740,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "fc35e947c750ea48a1dfa5db211e75017b448564d77db52ff3ecbcb64bcdb4ef"
+content-hash = "fba6b4a5948fbc1ed333c05824e40d758800bd1c14e35e7ca5240dddae4c3ef9"

--- a/action_server/pyproject.toml
+++ b/action_server/pyproject.toml
@@ -30,6 +30,7 @@ robocorp-actions = "^0.0.4"
 websockets = "^12.0"
 requests = "^2"
 psutil = "^5"
+rich = "^13.7.0"
 
 [tool.poetry.group.dev.dependencies]
 robocorp-devutils = { path = "../devutils/", develop = true }

--- a/action_server/src/robocorp/action_server/_actions_import.py
+++ b/action_server/src/robocorp/action_server/_actions_import.py
@@ -43,7 +43,7 @@ def import_action_package(
     from ._models import ActionPackage
     from ._rcc import create_hash, get_rcc
 
-    log.info("Importing action package from: %s", action_package_dir)
+    log.debug("Importing action package from: %s", action_package_dir)
 
     datadir = datadir.absolute()
     import_path = Path(action_package_dir).absolute()
@@ -80,7 +80,7 @@ Note: no virtual environment will be used for the imported actions, they'll be r
         if not contents.get("dependencies"):
             raise ActionPackageError(f"{conda_yaml} has no 'dependencies' specified.")
 
-        log.info(
+        log.debug(
             f"""Actions added with managed environment defined by: {conda_yaml}."""
         )
 
@@ -131,7 +131,7 @@ Note: no virtual environment will be used for the imported actions, they'll be r
         conda_hash=condahash,
         env_json=json.dumps(use_env),
     )
-    log.info(f"Collecting actions for Action Package: {name}.")
+    log.debug(f"Collecting actions for Action Package: {name}.")
 
     env = build_python_launch_env(use_env)
     _add_actions_to_db(
@@ -285,7 +285,7 @@ def _add_actions_to_db(
 
         seen_action_ids = set()
         with db.transaction():
-            log.info("Updating action package: %s", action_package.name)
+            log.debug("Updating action package: %s", action_package.name)
             db.update_by_id(
                 ActionPackage,
                 existing_action_package.id,
@@ -301,7 +301,7 @@ def _add_actions_to_db(
                     # This is an existing action, we need to update it.
                     new_action_as_dict = asdict(action)
                     del new_action_as_dict["id"]
-                    log.info("Updating action: %s", action.name)
+                    log.debug("Updating action: %s", action.name)
                     db.update_by_id(Action, existing_action.id, new_action_as_dict)
                     seen_action_ids.add(existing_action.id)
                 else:

--- a/action_server/src/robocorp/action_server/_actions_run.py
+++ b/action_server/src/robocorp/action_server/_actions_run.py
@@ -8,6 +8,7 @@ import typing
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Optional
 
+from fastapi import HTTPException
 from fastapi.params import Header, Param
 from pydantic import BaseModel
 
@@ -241,7 +242,7 @@ import it again from the new location.
 
                 def on_output(line):
                     stream.write(line)
-                    print("on_output:", line.strip())
+                    log.info(f"[dim bold]\[{action.name}]:[/] {line.strip()}")
 
                 with process.on_stderr.register(on_output), process.on_stdout.register(
                     on_output
@@ -276,7 +277,7 @@ import it again from the new location.
                     )
         except BaseException as e:
             _set_run_as_finished_failed(run, str(e), initial_time)
-            raise
+            raise HTTPException(status_code=500, detail=str(e))
 
 
 def _name_as_class_name(name):

--- a/action_server/src/robocorp/action_server/_errors.py
+++ b/action_server/src/robocorp/action_server/_errors.py
@@ -43,7 +43,7 @@ def _to_response(
     path: str,
     trace=False,
 ) -> Dict[str, Any]:
-    LOGGER.error("Invalid request: %s [%s]", message, path)
+    LOGGER.error("Invalid request: %s \[%s]", message, path)
     if trace:
         LOGGER.error(traceback.format_exc())
 

--- a/action_server/src/robocorp/action_server/_robo_utils/process.py
+++ b/action_server/src/robocorp/action_server/_robo_utils/process.py
@@ -114,7 +114,7 @@ class Process:
             partial(_popen_raise, self._args, **kwargs)
         )
         log.debug("Subprocess started [pid=%s,uid=%d]", proc.pid, self._uid)
-        _start_reader_threads(self._proc, self._on_stderr, self._on_stdout)
+        _start_reader_threads(self._proc, self._on_stdout, self._on_stderr)
 
     def _on_stderr(self, line):
         if len(self.on_stderr) > 0:

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -187,7 +187,7 @@ def start_server(
             loop.call_later(1 / 15.0, partial(expose_later, loop))
             return
 
-        (port, host) = _get_currrent_host()
+        (host, port) = _get_currrent_host()
 
         parent_pid = os.getpid()
 

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -210,6 +210,12 @@ def start_server(
         ]
         expose_subprocess = subprocess.Popen(args)
 
+    def _on_started_message(self, **kwargs):
+        bottom_padding = "" if expose else "\n"
+        log.info(
+            f"\n  [bold green]⚡️ Action Server started at http://{settings.address}:{settings.port}[/]{bottom_padding}"
+        )
+
     async def _on_startup():
         if expose:
             loop = asyncio.get_event_loop()
@@ -249,4 +255,6 @@ def start_server(
     kwargs = settings.to_uvicorn()
     config = uvicorn.Config(app=app, **kwargs)
     server = uvicorn.Server(config)
+    server._log_started_message = _on_started_message  # type: ignore[assignment]
+
     asyncio.run(server.serve())

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -174,7 +174,7 @@ def start_server(
                 raise Exception("Unable to find a port to expose")
             sockname = sockets_ipv4[0].getsockname()
             host = sockname[0]
-            port = sockname[1]  
+            port = sockname[1]
 
         return (host, port)
 

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -211,9 +211,8 @@ def start_server(
         expose_subprocess = subprocess.Popen(args)
 
     def _on_started_message(self, **kwargs):
-        bottom_padding = "" if expose else "\n"
         log.info(
-            f"\n  [bold green]⚡️ Action Server started at http://{settings.address}:{settings.port}[/]{bottom_padding}"
+            f"\n  [bold green]⚡️ Action Server started at http://{settings.address}:{settings.port}[/]\n"
         )
 
     async def _on_startup():

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -154,7 +154,7 @@ async def expose_server(
 
                             url = f"https://{session_payload.sessionId}.{expose_url}"
                             log.info(
-                                f"\n  [green][bold]🌍 Public URL:[/bold] [bright_blue]{url}[/]"
+                                f"  [green][bold]🌍 Public URL:[/bold] [bright_blue]{url}[/]"
                             )
                             if api_key is not None:
                                 log.info(

--- a/action_server/src/robocorp/action_server/_server_websockets.py
+++ b/action_server/src/robocorp/action_server/_server_websockets.py
@@ -179,7 +179,7 @@ async def websocket_endpoint(websocket: WebSocket):
                     # just log it and ignore.
                     log.info('Ignoring additional call to "start_listen_run_events"')
     except WebSocketDisconnect:
-        log.info("Client disconnected from websocket.")
+        log.debug("Client disconnected from websocket.")
     except Exception:
         log.exception("Unexpected exception from websocket.")
     finally:

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -279,7 +279,7 @@ def _setup_stdout_logging(log_level):
         show_path=is_debug,
         keywords=[],
         markup=True,
-        highlighter=NullHighlighter()
+        highlighter=NullHighlighter(),
     )
 
     rich_handler.setLevel(log_level)

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -279,6 +279,7 @@ def _setup_stdout_logging(log_level):
         show_path=is_debug,
         keywords=[],
         markup=True,
+        highlighter=NullHighlighter()
     )
 
     rich_handler.setLevel(log_level)


### PR DESCRIPTION
Note: This PR is highly opinionated, so all changes are welcome for discussion!

- Add `rich` library to highlight and format the cli output:
- Mark some of startup messages as `debug` level since they do give less useful information to the user (e.g. logging current yaml file path or websocket connection state to the UI)
- Highlight Action Server URL's as the most important startup information
- As a user request - override Uvicorn default startup message to replace it with an Action Server message - this one is done a bit hacky by overriding a class function, but I could not find a more cleaner way to do it. Printing the URL twice (uvicorn and action server) seems a worse alternative.
- Update uvicorn request formatting to display a timestamp also
<img width="1343" alt="image" src="https://github.com/robocorp/robocorp/assets/31288628/3840758f-329d-41fb-a55c-261eb7e00c93">
- Update `_run_action_in_thread` to fail with an `HTTPException` instead of the original error so the endpoint fails correctly with 500 error and action server does not show the error traceback to `_run_action_in_thread` which gives no useful information to the user:
<img width="1322" alt="image" src="https://github.com/robocorp/robocorp/assets/31288628/46335b01-3c79-47d1-8d22-0a2928985521">

