### PR TITLE
Feat: [Action Server] Server URL param

### DIFF
--- a/action_server/src/robocorp/action_server/_app.py
+++ b/action_server/src/robocorp/action_server/_app.py
@@ -14,7 +14,9 @@ LOGGER = logging.getLogger(__name__)
 @cache
 def get_app():
     settings = get_settings()
-    app = FastAPI(title=settings.title)
+
+    server = {"url": settings.server_url}
+    app = FastAPI(title=settings.title, servers=[server])
 
     app.add_middleware(
         CORSMiddleware,

--- a/action_server/src/robocorp/action_server/_selftest.py
+++ b/action_server/src/robocorp/action_server/_selftest.py
@@ -77,6 +77,7 @@ class ActionServerProcess:
         actions_sync=False,
         cwd: Optional[Path | str] = None,
         add_shutdown_api: bool = False,
+        additional_args: Optional[list[str]] = None
     ) -> None:
         from robocorp.action_server._robo_utils.process import Process
         from robocorp.action_server._settings import is_frozen
@@ -106,12 +107,16 @@ class ActionServerProcess:
             f"--datadir={str(self._datadir)}",
             f"--db-file={db_file}",
         ]
+
+        if additional_args:
+            new_args = new_args + additional_args
+
         env = {}
         if add_shutdown_api:
             env["RC_ADD_SHUTDOWN_API"] = "1"
         process = self._process = Process(new_args, cwd=cwd, env=env)
 
-        compiled = re.compile(r"http://([\w.-]+):(\d+)")
+        compiled = re.compile(r"Uvicorn running on http://([\w.-]+):(\d+)")
         future: Future[Tuple[str, str]] = Future()
 
         def collect_port_from_stdout(line):

--- a/action_server/src/robocorp/action_server/_selftest.py
+++ b/action_server/src/robocorp/action_server/_selftest.py
@@ -77,7 +77,7 @@ class ActionServerProcess:
         actions_sync=False,
         cwd: Optional[Path | str] = None,
         add_shutdown_api: bool = False,
-        additional_args: Optional[list[str]] = None
+        additional_args: Optional[list[str]] = None,
     ) -> None:
         from robocorp.action_server._robo_utils.process import Process
         from robocorp.action_server._settings import is_frozen

--- a/action_server/src/robocorp/action_server/_settings.py
+++ b/action_server/src/robocorp/action_server/_settings.py
@@ -61,6 +61,7 @@ class Settings:
     verbose: bool = False
     db_file: str = "server.db"
     expose_url: str = "robocorp.link"
+    server_url: str = "http://localhost:8080"
 
     @classmethod
     def defaults(cls):
@@ -105,6 +106,11 @@ class Settings:
 
         if hasattr(args, "port"):
             settings.port = args.port
+
+        if hasattr(args, "server_url") and args.server_url is not None:
+            settings.server_url = args.server_url
+        else:
+            settings.server_url = f"http://{settings.address}:{settings.port}"
 
         # Used in either import or start commands.
         settings.verbose = args.verbose

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -115,6 +115,14 @@ def _create_parser():
         help="Expose the server to the world",
     )
     start_parser.add_argument(
+        "--server-url",
+        help=(
+            "Explicit server url to be defined in the OpenAPI spec 'servers' section."
+            "Defaults to the localhost url."
+        ),
+        default=None,
+    )
+    start_parser.add_argument(
         "--expose-allow-reuse",
         dest="expose_allow_reuse",
         action="store_true",

--- a/action_server/tests/action_server_tests/test_server.py
+++ b/action_server/tests/action_server_tests/test_server.py
@@ -274,6 +274,16 @@ def test_routes(action_server_process: ActionServerProcess, data_regression):
 
     client.get_error("/api/runs/bad-run-id", 404)
 
+def test_server_url_flag(action_server_process: ActionServerProcess, data_regression):
+    action_server_process.start(
+        additional_args=["--server-url=https://foo.bar"]
+    )
+
+    client = ActionServerClient(action_server_process)
+    openapi_json = client.get_openapi_json()
+    spec = json.loads(openapi_json)
+    data_regression.check(spec)
+
 
 def test_subprocesses_killed(
     action_server_process: ActionServerProcess, client: ActionServerClient

--- a/action_server/tests/action_server_tests/test_server.py
+++ b/action_server/tests/action_server_tests/test_server.py
@@ -274,10 +274,9 @@ def test_routes(action_server_process: ActionServerProcess, data_regression):
 
     client.get_error("/api/runs/bad-run-id", 404)
 
+
 def test_server_url_flag(action_server_process: ActionServerProcess, data_regression):
-    action_server_process.start(
-        additional_args=["--server-url=https://foo.bar"]
-    )
+    action_server_process.start(additional_args=["--server-url=https://foo.bar"])
 
     client = ActionServerClient(action_server_process)
     openapi_json = client.get_openapi_json()

--- a/action_server/tests/action_server_tests/test_server/test_import.yml
+++ b/action_server/tests/action_server_tests/test_server/test_import.yml
@@ -466,3 +466,5 @@ paths:
                 type: string
           description: Successful Response
       summary: Serve Log Html
+servers:
+- url: http://localhost:0

--- a/action_server/tests/action_server_tests/test_server/test_import_no_conda.txt
+++ b/action_server/tests/action_server_tests/test_server/test_import_no_conda.txt
@@ -4,6 +4,11 @@
         "title": "Robocorp Actions Server",
         "version": "0.1.0"
     },
+    "servers": [
+        {
+            "url": "http://localhost:0"
+        }
+    ],
     "paths": {
         "/api/actions/calculator/calculator-sum/run": {
             "post": {

--- a/action_server/tests/action_server_tests/test_server/test_routes.yml
+++ b/action_server/tests/action_server_tests/test_server/test_routes.yml
@@ -396,3 +396,5 @@ paths:
                 type: string
           description: Successful Response
       summary: Serve Log Html
+servers:
+- url: http://localhost:0

--- a/action_server/tests/action_server_tests/test_server/test_schema_request_no_actions_registered.yml
+++ b/action_server/tests/action_server_tests/test_server/test_schema_request_no_actions_registered.yml
@@ -355,3 +355,5 @@ paths:
                 type: string
           description: Successful Response
       summary: Serve Log Html
+servers:
+- url: http://localhost:0

--- a/action_server/tests/action_server_tests/test_server/test_server_url_flag.yml
+++ b/action_server/tests/action_server_tests/test_server/test_server_url_flag.yml
@@ -1,0 +1,359 @@
+components:
+  schemas:
+    Action:
+      properties:
+        action_package_id:
+          title: Action Package Id
+          type: string
+        docs:
+          title: Docs
+          type: string
+        enabled:
+          default: true
+          title: Enabled
+          type: boolean
+        file:
+          title: File
+          type: string
+        id:
+          title: Id
+          type: string
+        input_schema:
+          title: Input Schema
+          type: string
+        is_consequential:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Consequential
+        lineno:
+          title: Lineno
+          type: integer
+        name:
+          title: Name
+          type: string
+        output_schema:
+          title: Output Schema
+          type: string
+      required:
+      - id
+      - action_package_id
+      - name
+      - docs
+      - file
+      - lineno
+      - input_schema
+      - output_schema
+      title: Action
+      type: object
+    ActionPackageApi:
+      properties:
+        actions:
+          items:
+            $ref: '#/components/schemas/Action'
+          title: Actions
+          type: array
+        id:
+          title: Id
+          type: string
+        name:
+          title: Name
+          type: string
+      required:
+      - id
+      - name
+      - actions
+      title: ActionPackageApi
+      type: object
+    ArtifactInfo:
+      properties:
+        name:
+          title: Name
+          type: string
+        size_in_bytes:
+          title: Size In Bytes
+          type: integer
+      required:
+      - name
+      - size_in_bytes
+      title: ArtifactInfo
+      type: object
+    HTTPValidationError:
+      properties:
+        errors:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          title: Errors
+          type: array
+      title: HTTPValidationError
+      type: object
+    Run:
+      properties:
+        action_id:
+          title: Action Id
+          type: string
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+        id:
+          title: Id
+          type: string
+        inputs:
+          title: Inputs
+          type: string
+        numbered_id:
+          title: Numbered Id
+          type: integer
+        relative_artifacts_dir:
+          title: Relative Artifacts Dir
+          type: string
+        result:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Result
+        run_time:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Run Time
+        start_time:
+          title: Start Time
+          type: string
+        status:
+          title: Status
+          type: integer
+      required:
+      - id
+      - status
+      - action_id
+      - start_time
+      - run_time
+      - inputs
+      - result
+      - error_message
+      - relative_artifacts_dir
+      - numbered_id
+      title: Run
+      type: object
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          title: Location
+          type: array
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+      type: object
+info:
+  title: Robocorp Actions Server
+  version: 0.1.0
+openapi: 3.1.0
+paths:
+  /api/actionPackages:
+    get:
+      operationId: list_action_packages_api_actionPackages_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ActionPackageApi'
+                title: Response List Action Packages Api Actionpackages Get
+                type: array
+          description: Successful Response
+      summary: List Action Packages
+  /api/runs:
+    get:
+      operationId: list_runs_api_runs_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Run'
+                title: Response List Runs Api Runs Get
+                type: array
+          description: Successful Response
+      summary: List Runs
+  /api/runs/{run_id}:
+    get:
+      operationId: show_run_api_runs__run_id__get
+      parameters:
+      - in: path
+        name: run_id
+        required: true
+        schema:
+          title: ID for run
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Run'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Show Run
+  /api/runs/{run_id}/artifacts:
+    get:
+      operationId: get_run_artifacts_api_runs__run_id__artifacts_get
+      parameters:
+      - in: path
+        name: run_id
+        required: true
+        schema:
+          title: ID for run
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                description: 'Provides a list with the artifacts available
+
+                  for a given run (i.e.: [{''name'': ''__action_server_output.txt'',
+                  ''size_in_bytes'': 22}])
+
+                  '
+                items:
+                  $ref: '#/components/schemas/ArtifactInfo'
+                title: Response Get Run Artifacts Api Runs  Run Id  Artifacts Get
+                type: array
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Run Artifacts
+  /api/runs/{run_id}/artifacts/binary-content:
+    get:
+      operationId: get_run_artifact_binary_api_runs__run_id__artifacts_binary_content_get
+      parameters:
+      - in: path
+        name: run_id
+        required: true
+        schema:
+          title: ID for run
+          type: string
+      - in: query
+        name: artifact_name
+        required: true
+        schema:
+          title: Artifact name for which the content should be gotten.
+          type: string
+      responses:
+        '200':
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Run Artifact Binary
+  /api/runs/{run_id}/artifacts/text-content:
+    get:
+      operationId: get_run_artifact_text_api_runs__run_id__artifacts_text_content_get
+      parameters:
+      - in: path
+        name: run_id
+        required: true
+        schema:
+          title: ID for run
+          type: string
+      - in: query
+        name: artifact_names
+        required: false
+        schema:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Artifact names for which the content should be gotten.
+      - in: query
+        name: artifact_name_regexp
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: A regexp to match artifact names.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                title: Response Get Run Artifact Text Api Runs  Run Id  Artifacts
+                  Text Content Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Run Artifact Text
+  /api/runs/{run_id}/log.html:
+    get:
+      operationId: get_run_log_html_api_runs__run_id__log_html_get
+      parameters:
+      - in: path
+        name: run_id
+        required: true
+        schema:
+          title: ID for run
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Run Log Html
+  /base_log.html:
+    get:
+      operationId: serve_log_html_base_log_html_get
+      responses:
+        '200':
+          content:
+            text/html:
+              schema:
+                type: string
+          description: Successful Response
+      summary: Serve Log Html
+servers:
+- url: https://foo.bar


### PR DESCRIPTION
Add `--server-url` cli parameter that adds the URL to the OpenAPI spec `servers` section. By default, the localhost url is added:
```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "Robocorp Actions Server",
    "version": "0.1.0"
  },
  "servers": [
    {
      "url": "http://localhost:8080"
    }
  ]
```

The `servers` section entry is required for AI applications to acknowledge the API server endpoint URL. This allows a user to define the url when starting the server (e.g. by passing the final public url via an env environment on cloud deployments).

No special treatment is required when using `--expose` flag as the robocorp.link tunnel handles adjusting the OpenAPI schema.