### PR TITLE
Feat: [Action Server] Move route auth to app level

### DIFF
--- a/action_server/frontend/src/lib/requestData.ts
+++ b/action_server/frontend/src/lib/requestData.ts
@@ -27,6 +27,7 @@ const loadAsync = async <T>(
   url: string,
   method: 'POST' | 'GET',
   opts: Opts | undefined = undefined,
+  headers: HeadersInit | undefined = undefined,
 ): Promise<CachedModel<T>> => {
   try {
     const body: string | undefined = opts?.body;
@@ -42,6 +43,7 @@ const loadAsync = async <T>(
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
+        ...headers,
       },
     };
     if (body !== undefined) {
@@ -402,15 +404,22 @@ export const runAction = async (
   actionName: string,
   args: object,
   setLoaded: Dispatch<SetStateAction<AsyncLoaded<any>>>,
+  apiKey?: string,
 ) => {
   setLoaded({
     isPending: true,
     data: undefined,
   });
+
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+  };
+
   const data = await loadAsync(
     `${baseUrl}/api/actions/${actionPackageName}/${actionName}/run`,
     'POST',
     { body: JSON.stringify(args) },
+    headers,
   );
   setLoaded(data);
 };

--- a/action_server/frontend/src/lib/types.ts
+++ b/action_server/frontend/src/lib/types.ts
@@ -69,4 +69,5 @@ export enum InputPropertyType {
 
 export type ServerConfig = {
   expose_url: string;
+  auth_enabled: boolean;
 };

--- a/action_server/src/robocorp/action_server/_robo_utils/auth.py
+++ b/action_server/src/robocorp/action_server/_robo_utils/auth.py
@@ -1,5 +1,3 @@
-import os
-from typing import Optional
 from pathlib import Path
 
 
@@ -10,18 +8,15 @@ def generate_api_key():
 
 
 def get_api_key(datadir: Path) -> str:
-    api_key_path = os.path.join(datadir, ".api_key")
+    api_key_path = datadir / ".api_key"
 
     try:
-        with open(api_key_path, "r") as file:
-            api_key = file.read()
+        api_key = api_key_path.read_text("utf-8")
     except Exception:
         api_key = ""
 
     if len(api_key) == 0:
         api_key = generate_api_key()
-
-        with open(api_key_path, "w") as file:
-            file.write(api_key)
+        api_key_path.write_text(api_key, "utf-8")
 
     return api_key

--- a/action_server/src/robocorp/action_server/_robo_utils/auth.py
+++ b/action_server/src/robocorp/action_server/_robo_utils/auth.py
@@ -1,4 +1,30 @@
+import os
+from typing import Optional
+from pathlib import Path
+
+
 def generate_api_key():
     import secrets
 
     return secrets.token_urlsafe(32)
+
+
+def get_api_key(datadir: Path, explicit_api_key: Optional[str]) -> str:
+    api_key_path = os.path.join(datadir, ".api_key")
+
+    if explicit_api_key:
+        return explicit_api_key
+
+    try:
+        with open(api_key_path, "r") as file:
+            api_key = file.read()
+    except Exception:
+        api_key = ""
+
+    if len(api_key) == 0:
+        api_key = generate_api_key()
+
+        with open(api_key_path, "w") as file:
+            file.write(api_key)
+
+    return api_key

--- a/action_server/src/robocorp/action_server/_robo_utils/auth.py
+++ b/action_server/src/robocorp/action_server/_robo_utils/auth.py
@@ -9,11 +9,8 @@ def generate_api_key():
     return secrets.token_urlsafe(32)
 
 
-def get_api_key(datadir: Path, explicit_api_key: Optional[str]) -> str:
+def get_api_key(datadir: Path) -> str:
     api_key_path = os.path.join(datadir, ".api_key")
-
-    if explicit_api_key:
-        return explicit_api_key
 
     try:
         with open(api_key_path, "r") as file:

--- a/action_server/src/robocorp/action_server/_selftest.py
+++ b/action_server/src/robocorp/action_server/_selftest.py
@@ -116,7 +116,7 @@ class ActionServerProcess:
             env["RC_ADD_SHUTDOWN_API"] = "1"
         process = self._process = Process(new_args, cwd=cwd, env=env)
 
-        compiled = re.compile(r"Uvicorn running on http://([\w.-]+):(\d+)")
+        compiled = re.compile(r"Action Server started at http://([\w.-]+):(\d+)")
         future: Future[Tuple[str, str]] = Future()
 
         def collect_port_from_stdout(line):
@@ -199,10 +199,10 @@ class ActionServerClient:
         except Exception:
             raise AssertionError(f"Unable to load: {contents!r}")
 
-    def post_get_str(self, url, data):
+    def post_get_str(self, url, data, headers: Optional[dict] | None = None):
         import requests
 
-        result = requests.post(self.build_full_url(url), json=data)
+        result = requests.post(self.build_full_url(url), headers=headers, json=data)
         assert result.status_code == 200
         return result.text
 

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -6,6 +6,9 @@ import subprocess
 import sys
 from functools import partial
 from typing import Dict, Optional
+from fastapi import Depends, Security, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
 
 from ._server_expose import get_expose_session_payload, read_expose_session_json
 
@@ -57,6 +60,22 @@ def start_server(
         (action_package.id, action_package) for action_package in db.all(ActionPackage)
     )
 
+    def verify_api_key(
+        token: HTTPAuthorizationCredentials = Security(HTTPBearer(auto_error=True)),
+    ) -> HTTPAuthorizationCredentials:
+        if token.credentials != api_key:
+            raise HTTPException(
+                status_code=403,
+                detail="Invalid or missing API Key",
+            )
+        else:
+            return token
+
+    endpoint_dependencies = []
+
+    if api_key:
+        endpoint_dependencies.append(Depends(verify_api_key))
+
     for action in db.all(Action):
         if not action.enabled:
             # Disabled actions should not be registered.
@@ -89,6 +108,7 @@ def start_server(
             description=doc_desc,
             operation_id=action.name,
             methods=["POST"],
+            dependencies=endpoint_dependencies,
             openapi_extra={
                 "x-openai-isConsequential": action.is_consequential,
             }
@@ -121,7 +141,13 @@ def start_server(
 
     @app.get("/config", include_in_schema=False)
     async def serve_config():
-        payload = {"expose_url": False}
+        payload = {
+            "expose_url": False,
+            "auth_enabled": False
+        }
+
+        if api_key:
+            payload["auth_enabled"] = True
 
         if expose:
             current_expose_session = read_expose_session_json(
@@ -163,15 +189,7 @@ def start_server(
 
     expose_subprocess = None
 
-    def expose_later(loop):
-        from robocorp.action_server._settings import is_frozen
-
-        nonlocal expose_subprocess
-
-        if not server.started:
-            loop.call_later(1 / 15.0, partial(expose_later, loop))
-            return
-
+    def _get_currrent_host():
         port = settings.port if settings.port != 0 else None
         host = settings.address
         if port is None:
@@ -183,6 +201,19 @@ def start_server(
             sockname = sockets_ipv4[0].getsockname()
             host = sockname[0]
             port = sockname[1]
+
+        return (host, port)
+
+    def expose_later(loop):
+        from robocorp.action_server._settings import is_frozen
+
+        nonlocal expose_subprocess
+
+        if not server.started:
+            loop.call_later(1 / 15.0, partial(expose_later, loop))
+            return
+
+        (host, port) = _get_currrent_host()
 
         parent_pid = os.getpid()
 
@@ -205,10 +236,18 @@ def start_server(
             host,
             settings.expose_url,
             settings.datadir,
-            str(api_key),
             str(expose_session),
         ]
         expose_subprocess = subprocess.Popen(args)
+
+    def _on_started_message(self, **kwargs):
+        (host, port) = _get_currrent_host()
+        log.info(f"\n  ⚡️ Action Server started at http://{settings.address}:{port}")
+
+        if api_key:
+            log.info(
+                f'  🔑 API Authorization key: {{ "Authorization": "Bearer {api_key}"}}'
+            )
 
     async def _on_startup():
         if expose:
@@ -249,4 +288,7 @@ def start_server(
     kwargs = settings.to_uvicorn()
     config = uvicorn.Config(app=app, **kwargs)
     server = uvicorn.Server(config)
+
+    server._log_started_message = _on_started_message  # type: ignore[assignment]
+
     asyncio.run(server.serve())

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -141,10 +141,7 @@ def start_server(
 
     @app.get("/config", include_in_schema=False)
     async def serve_config():
-        payload = {
-            "expose_url": False,
-            "auth_enabled": False
-        }
+        payload = {"expose_url": False, "auth_enabled": False}
 
         if api_key:
             payload["auth_enabled"] = True

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -121,7 +121,6 @@ async def expose_server(
     host: str,
     expose_url: str,
     datadir: str,
-
     expose_session: str | None = None,
 ):
     """

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -31,7 +31,6 @@ class BodyPayload(BaseModel):
 class ExposeSessionJson(BaseModel):
     expose_session: str
     url: str
-    api_key: str | None = None
 
 
 def get_expose_session_path(datadir: str) -> str:
@@ -122,7 +121,7 @@ async def expose_server(
     host: str,
     expose_url: str,
     datadir: str,
-    api_key: str | None = None,
+
     expose_session: str | None = None,
 ):
     """
@@ -192,17 +191,12 @@ async def expose_server(
                                 url = (
                                     f"https://{session_payload.sessionId}.{expose_url}"
                                 )
-                                log.info(f"🌍 URL: {url}")
-                                if api_key is not None:
-                                    log.info(
-                                        f'🔑 Add following header api authorization header to run actions: {{ "Authorization": "Bearer {api_key}" }}'  # noqa
-                                    )
+                                log.info(f"  🌍 Public URL: {url}\n")
                                 new_expose_session = get_expose_session(session_payload)
                                 write_expose_session_json(
                                     datadir=datadir,
                                     expose_session_json=ExposeSessionJson(
                                         expose_session=new_expose_session,
-                                        api_key=api_key,
                                         url=url,
                                     ),
                                 )
@@ -217,35 +211,6 @@ async def expose_server(
 
                             try:
                                 payload = BodyPayload(**data)
-                                if (
-                                    payload.path != "/openapi.json"
-                                    and api_key is not None
-                                ):
-                                    if (
-                                        payload.headers.get("authorization")
-                                        != f"Bearer {api_key}"
-                                    ):
-                                        log.error(
-                                            "Request failed because the API key is invalid."
-                                        )
-                                        await ws.send(
-                                            json.dumps(
-                                                {
-                                                    "requestId": payload.requestId,
-                                                    "response": json.dumps(
-                                                        {
-                                                            "error": {
-                                                                "code": "INVALID_API_KEY",
-                                                                "message": "The API key is invalid.",
-                                                            },
-                                                        }
-                                                    ),
-                                                    "status": 403,
-                                                }
-                                            )
-                                        )
-                                        continue
-
                                 base_url = f"http://{host}:{port}"
                                 response: requests.Response = forward_request(
                                     base_url=base_url, payload=payload
@@ -303,7 +268,7 @@ async def expose_server(
     await task  # Wait for listen_for_requests to complete
 
 
-def main(parent_pid, port, verbose, host, expose_url, datadir, api_key, expose_session):
+def main(parent_pid, port, verbose, host, expose_url, datadir, expose_session):
     logging.basicConfig(
         level=logging.DEBUG if verbose.count("v") > 0 else logging.INFO,
         format="%(message)s",
@@ -318,7 +283,6 @@ def main(parent_pid, port, verbose, host, expose_url, datadir, api_key, expose_s
                 host=host,
                 expose_url=expose_url,
                 datadir=datadir,
-                api_key=api_key if api_key != "None" else None,
                 expose_session=expose_session if expose_session != "None" else None,
             )
         )

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -501,9 +501,9 @@ To migrate the database to the current version
 
                             api_key = None
                             if base_args.api_key:
-                                api_key = get_api_key(
-                                    settings.datadir, base_args.api_key
-                                )
+                                api_key = base_args.api_key
+                            elif base_args.expose:
+                                api_key = get_api_key(settings.datadir)
 
                             start_server(
                                 expose=base_args.expose,

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 from typing import Optional, Union
 
-from robocorp.action_server._robo_utils.auth import generate_api_key
+from robocorp.action_server._robo_utils.auth import get_api_key
 
 from . import __version__
 
@@ -499,13 +499,11 @@ To migrate the database to the current version
                                     else:
                                         expose_session = None
 
-                            api_key = base_args.api_key
-                            if api_key is None:
-                                # reuse the previously exposed api key
-                                if expose_session and expose_session.api_key:
-                                    api_key = expose_session.api_key
-                                else:
-                                    api_key = generate_api_key()
+                            api_key = None
+                            if base_args.api_key:
+                                api_key = get_api_key(
+                                    settings.datadir, base_args.api_key
+                                )
 
                             start_server(
                                 expose=base_args.expose,

--- a/action_server/tests/action_server_tests/test_server.py
+++ b/action_server/tests/action_server_tests/test_server.py
@@ -284,6 +284,32 @@ def test_server_url_flag(action_server_process: ActionServerProcess, data_regres
     data_regression.check(spec)
 
 
+def test_auth_routes(action_server_process: ActionServerProcess, data_regression):
+    from action_server_tests.fixtures import get_in_resources
+
+    pack = get_in_resources("greeter")
+    action_server_process.start(
+        cwd=pack,
+        actions_sync=True,
+        db_file="server.db",
+        additional_args=["--api-key=Foo"],
+    )
+
+    client = ActionServerClient(action_server_process)
+    openapi_json = client.get_openapi_json()
+    spec = json.loads(openapi_json)
+    data_regression.check(spec)
+
+    client.post_error("api/actions/greeter/greet/run", 403)
+
+    found = client.post_get_str(
+        "api/actions/greeter/greet/run",
+        {"name": "Foo"},
+        {"Authorization": "Bearer Foo"},
+    )
+    assert found == '"Hello Mr. Foo."', f"{found} != '\"Hello Mr. Foo.\"'"
+
+
 def test_subprocesses_killed(
     action_server_process: ActionServerProcess, client: ActionServerClient
 ):

--- a/action_server/tests/action_server_tests/test_server.py
+++ b/action_server/tests/action_server_tests/test_server.py
@@ -287,7 +287,7 @@ def test_server_url_flag(action_server_process: ActionServerProcess, data_regres
 def test_auth_routes(action_server_process: ActionServerProcess, data_regression):
     from action_server_tests.fixtures import get_in_resources
 
-    pack = get_in_resources("greeter")
+    pack = get_in_resources("no_conda", "greeter")
     action_server_process.start(
         cwd=pack,
         actions_sync=True,

--- a/action_server/tests/action_server_tests/test_server/test_auth_routes.yml
+++ b/action_server/tests/action_server_tests/test_server/test_auth_routes.yml
@@ -1,0 +1,406 @@
+components:
+  schemas:
+    Action:
+      properties:
+        action_package_id:
+          title: Action Package Id
+          type: string
+        docs:
+          title: Docs
+          type: string
+        enabled:
+          default: true
+          title: Enabled
+          type: boolean
+        file:
+          title: File
+          type: string
+        id:
+          title: Id
+          type: string
+        input_schema:
+          title: Input Schema
+          type: string
+        is_consequential:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Consequential
+        lineno:
+          title: Lineno
+          type: integer
+        name:
+          title: Name
+          type: string
+        output_schema:
+          title: Output Schema
+          type: string
+      required:
+      - id
+      - action_package_id
+      - name
+      - docs
+      - file
+      - lineno
+      - input_schema
+      - output_schema
+      title: Action
+      type: object
+    ActionPackageApi:
+      properties:
+        actions:
+          items:
+            $ref: '#/components/schemas/Action'
+          title: Actions
+          type: array
+        id:
+          title: Id
+          type: string
+        name:
+          title: Name
+          type: string
+      required:
+      - id
+      - name
+      - actions
+      title: ActionPackageApi
+      type: object
+    ArtifactInfo:
+      properties:
+        name:
+          title: Name
+          type: string
+        size_in_bytes:
+          title: Size In Bytes
+          type: integer
+      required:
+      - name
+      - size_in_bytes
+      title: ArtifactInfo
+      type: object
+    GreetInput:
+      properties:
+        name:
+          description: The name of the person to greet.
+          title: Name
+          type: string
+        title:
+          default: Mr.
+          description: The title for the persor (Mr., Mrs., ...).
+          title: Title
+          type: string
+      required:
+      - name
+      title: GreetInput
+      type: object
+    HTTPValidationError:
+      properties:
+        errors:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          title: Errors
+          type: array
+      title: HTTPValidationError
+      type: object
+    Run:
+      properties:
+        action_id:
+          title: Action Id
+          type: string
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+        id:
+          title: Id
+          type: string
+        inputs:
+          title: Inputs
+          type: string
+        numbered_id:
+          title: Numbered Id
+          type: integer
+        relative_artifacts_dir:
+          title: Relative Artifacts Dir
+          type: string
+        result:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Result
+        run_time:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Run Time
+        start_time:
+          title: Start Time
+          type: string
+        status:
+          title: Status
+          type: integer
+      required:
+      - id
+      - status
+      - action_id
+      - start_time
+      - run_time
+      - inputs
+      - result
+      - error_message
+      - relative_artifacts_dir
+      - numbered_id
+      title: Run
+      type: object
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          title: Location
+          type: array
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+      type: object
+  securitySchemes:
+    HTTPBearer:
+      scheme: bearer
+      type: http
+info:
+  title: Robocorp Actions Server
+  version: 0.1.0
+openapi: 3.1.0
+paths:
+  /api/actionPackages:
+    get:
+      operationId: list_action_packages_api_actionPackages_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ActionPackageApi'
+                title: Response List Action Packages Api Actionpackages Get
+                type: array
+          description: Successful Response
+      summary: List Action Packages
+  /api/actions/greeter/greet/run:
+    post:
+      description: Provides a greeting for a person.
+      operationId: greet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GreetInput'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                description: The greeting for the person.
+                title: Response Greet
+                type: string
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - HTTPBearer: []
+      summary: Greet
+  /api/runs:
+    get:
+      operationId: list_runs_api_runs_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Run'
+                title: Response List Runs Api Runs Get
+                type: array
+          description: Successful Response
+      summary: List Runs
+  /api/runs/{run_id}:
+    get:
+      operationId: show_run_api_runs__run_id__get
+      parameters:
+      - in: path
+        name: run_id
+        required: true
+        schema:
+          title: ID for run
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Run'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Show Run
+  /api/runs/{run_id}/artifacts:
+    get:
+      operationId: get_run_artifacts_api_runs__run_id__artifacts_get
+      parameters:
+      - in: path
+        name: run_id
+        required: true
+        schema:
+          title: ID for run
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                description: 'Provides a list with the artifacts available
+
+                  for a given run (i.e.: [{''name'': ''__action_server_output.txt'',
+                  ''size_in_bytes'': 22}])
+
+                  '
+                items:
+                  $ref: '#/components/schemas/ArtifactInfo'
+                title: Response Get Run Artifacts Api Runs  Run Id  Artifacts Get
+                type: array
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Run Artifacts
+  /api/runs/{run_id}/artifacts/binary-content:
+    get:
+      operationId: get_run_artifact_binary_api_runs__run_id__artifacts_binary_content_get
+      parameters:
+      - in: path
+        name: run_id
+        required: true
+        schema:
+          title: ID for run
+          type: string
+      - in: query
+        name: artifact_name
+        required: true
+        schema:
+          title: Artifact name for which the content should be gotten.
+          type: string
+      responses:
+        '200':
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Run Artifact Binary
+  /api/runs/{run_id}/artifacts/text-content:
+    get:
+      operationId: get_run_artifact_text_api_runs__run_id__artifacts_text_content_get
+      parameters:
+      - in: path
+        name: run_id
+        required: true
+        schema:
+          title: ID for run
+          type: string
+      - in: query
+        name: artifact_names
+        required: false
+        schema:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Artifact names for which the content should be gotten.
+      - in: query
+        name: artifact_name_regexp
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: A regexp to match artifact names.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                title: Response Get Run Artifact Text Api Runs  Run Id  Artifacts
+                  Text Content Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Run Artifact Text
+  /api/runs/{run_id}/log.html:
+    get:
+      operationId: get_run_log_html_api_runs__run_id__log_html_get
+      parameters:
+      - in: path
+        name: run_id
+        required: true
+        schema:
+          title: ID for run
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Run Log Html
+  /base_log.html:
+    get:
+      operationId: serve_log_html_base_log_html_get
+      responses:
+        '200':
+          content:
+            text/html:
+              schema:
+                type: string
+          description: Successful Response
+      summary: Serve Log Html
+servers:
+- url: http://localhost:0


### PR DESCRIPTION
Move action execution authorization to the application level instead of exposed server only. This enables the user passed API key `--api-key=XXX` parameter to be used by Action Server for authorization also for local requests.  Current use of `--expose` is not changed and the API key is persisted.

This feature is required to enable authorization without using `--expose`, for example, when deploying the Action Server manually.

Added also the option to input the API key in the Action Server UI.