### PR TITLE
feat: refactor expose ping logic

### DIFF
--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -189,7 +189,6 @@ async def expose_server(
     pong_queue: asyncio.Queue = asyncio.Queue(maxsize=1)
 
     async def listen_for_requests() -> None:
-        max_retries = 3
         retry_delay = 3
         retries = 0
 
@@ -253,7 +252,7 @@ async def expose_server(
                                 continue
             except websockets.exceptions.ConnectionClosedError:
                 retries += 1
-                log.info(f"Reconnecting to expose server ({retries}/{max_retries})")
+                log.info("Lost connection. Reconnecting to expose server...")
                 await asyncio.sleep(retry_delay * retries)
                 continue
             except socket.gaierror:

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -269,7 +269,6 @@ async def expose_server(
                 try:
                     await ping_task
                 except asyncio.CancelledError as e:
-                    print(e)
                     pass
         else:
             log.info("Expose server connection closed")

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -133,7 +133,7 @@ async def handle_ping_pong(
 
 
 def handle_session_payload(
-    session_payload: SessionPayload,  expose_url: str, datadir: str
+    session_payload: SessionPayload, expose_url: str, datadir: str
 ):
     url = f"https://{session_payload.sessionId}.{expose_url}"
     log.info(f"  🌍 Public URL: {url}\n")

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -17,25 +17,6 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-# websockets logger will log the retries with the stack trace. this makes it less verbose.
-class NoExceptionFormatter(logging.Formatter):
-    def format(self, record):
-        record.exc_info = None
-        return super().format(record)
-
-
-console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.DEBUG)
-
-formatter = NoExceptionFormatter("%(message)s")
-console_handler.setFormatter(formatter)
-
-
-websockets_logger = logging.getLogger("websockets")
-websockets_logger.addHandler(console_handler)
-websockets_logger.propagate = False
-
-
 class SessionPayload(BaseModel):
     sessionId: str
     sessionSecret: str
@@ -196,7 +177,7 @@ async def expose_server(
         async for ws in websockets.connect(
             f"wss://client.{expose_url}",
             extra_headers=headers,
-            logger=websockets_logger,
+            logger=log,
             open_timeout=2,
             close_timeout=0,
         ):

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -210,8 +210,6 @@ async def expose_server(
             f"wss://client.{expose_url}",
             extra_headers=headers,
             logger=websockets_logger,
-            ping_interval=None,
-            close_timeout=0,
         ):
             if retries > 0:
                 retries = 0

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -15,6 +15,10 @@ from robocorp.action_server._robo_utils.process import exit_when_pid_exists
 
 log = logging.getLogger(__name__)
 
+# disable websockets logger. It's too verbose
+websockets_logger = logging.getLogger("websockets")
+websockets_logger.setLevel(logging.ERROR)
+
 
 class SessionPayload(BaseModel):
     sessionId: str
@@ -205,10 +209,13 @@ async def expose_server(
         async for ws in websockets.connect(
             f"wss://client.{expose_url}",
             extra_headers=headers,
-            logger=log,
+            logger=websockets_logger,
             ping_interval=None,
             close_timeout=0,
         ):
+            if retries > 0:
+                retries = 0
+
             ping_task = asyncio.create_task(
                 handle_ping_pong(ws, pong_queue, ping_interval)
             )

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -133,8 +133,8 @@ async def handle_ping_pong(
 
 
 def handle_session_payload(
-    session_payload: SessionPayload, api_key: str, expose_url: str, datadir: str
-) -> None:
+    session_payload: SessionPayload, api_key: str | None, expose_url: str, datadir: str
+):
     url = f"https://{session_payload.sessionId}.{expose_url}"
     log.info(f"🌍 URL: {url}")
     if api_key is not None:
@@ -154,9 +154,9 @@ def handle_session_payload(
 
 def handle_body_payload(
     payload: BodyPayload,
-    api_key: str,
+    api_key: str | None,
     base_url: str,
-) -> str:
+):
     if payload.path != "/openapi.json" and api_key is not None:
         if payload.headers.get("authorization") != f"Bearer {api_key}":
             log.error("Request failed because the API key is invalid.")

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -16,7 +16,7 @@ from robocorp.action_server._robo_utils.process import exit_when_pid_exists
 log = logging.getLogger(__name__)
 
 
-# disable websockets logger. It's too verbose
+# websockets logger will log the retries with the stack trace. this makes it less verbose.
 class NoExceptionFormatter(logging.Formatter):
     def format(self, record):
         record.exc_info = None
@@ -135,7 +135,7 @@ async def handle_ping_pong(
 def handle_session_payload(
     session_payload: SessionPayload, api_key: str, expose_url: str, datadir: str
 ) -> None:
-    url = f"http://{expose_url}?sessionId={session_payload.sessionId}"
+    url = f"https://{session_payload.sessionId}.{expose_url}"
     log.info(f"🌍 URL: {url}")
     if api_key is not None:
         log.info(
@@ -222,7 +222,7 @@ async def expose_server(
 
         while True:
             async for ws in websockets.connect(
-                f"ws://{expose_url}",
+                f"wss://client.{expose_url}",
                 extra_headers=headers,
                 logger=websockets_logger,
                 open_timeout=2,
@@ -238,9 +238,7 @@ async def expose_server(
                 try:
                     while True:
                         message = await ws.recv()
-                        if message == "no_connection":
-                            continue
-                        elif message == "pong":
+                        if message == "pong":
                             await pong_queue.put("pong")
                             continue
 

--- a/action_server/src/robocorp/action_server/_settings.py
+++ b/action_server/src/robocorp/action_server/_settings.py
@@ -60,8 +60,7 @@ class Settings:
     port: int = 8080
     verbose: bool = False
     db_file: str = "server.db"
-    # expose_url: str = "robocorp.link"
-    expose_url: str = "localhost:8787"
+    expose_url: str = "robocorp.link"
     server_url: str = "http://localhost:8080"
 
     @classmethod

--- a/action_server/src/robocorp/action_server/_settings.py
+++ b/action_server/src/robocorp/action_server/_settings.py
@@ -60,7 +60,8 @@ class Settings:
     port: int = 8080
     verbose: bool = False
     db_file: str = "server.db"
-    expose_url: str = "robocorp.link"
+    # expose_url: str = "robocorp.link"
+    expose_url: str = "localhost:8787"
     server_url: str = "http://localhost:8080"
 
     @classmethod


### PR DESCRIPTION
- Now uses `websockets` re-connection mechanisms
- Refactored payload handling to separate functions
- Workaround for `websockets` logger to not print stack trace when re-connecting

## Preview

https://github.com/robocorp/robocorp/assets/1479451/bebb9060-8c92-4138-a274-4eb1402c3ce6
