### PR TITLE
Chore:[Action Server] Improve output logging format

### DIFF
--- a/action_server/poetry.lock
+++ b/action_server/poetry.lock
@@ -1027,6 +1027,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1034,8 +1035,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1052,6 +1060,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1059,6 +1068,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1385,6 +1395,20 @@ anyio = ">=3.4.0,<5"
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
 
 [[package]]
+name = "termcolor"
+version = "2.4.0"
+description = "ANSI color formatting for output in terminal"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "termcolor-2.4.0-py3-none-any.whl", hash = "sha256:9297c0df9c99445c2412e832e882a7884038a25617c60cea2ad69488d4040d63"},
+    {file = "termcolor-2.4.0.tar.gz", hash = "sha256:aab9e56047c8ac41ed798fa36d892a37aca6b3e9159f3e0c24bc64a9b3ac7b7a"},
+]
+
+[package.extras]
+tests = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1697,4 +1721,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "fc35e947c750ea48a1dfa5db211e75017b448564d77db52ff3ecbcb64bcdb4ef"
+content-hash = "8759697fdef1a4c1cd5442b69c8dba5be8e4543d9e7545d8f6f47fe4ba4f96ca"

--- a/action_server/pyproject.toml
+++ b/action_server/pyproject.toml
@@ -30,6 +30,7 @@ robocorp-actions = "^0.0.4"
 websockets = "^12.0"
 requests = "^2"
 psutil = "^5"
+termcolor = "^2.4.0"
 
 [tool.poetry.group.dev.dependencies]
 robocorp-devutils = { path = "../devutils/", develop = true }

--- a/action_server/src/robocorp/action_server/_actions_import.py
+++ b/action_server/src/robocorp/action_server/_actions_import.py
@@ -4,6 +4,7 @@ import subprocess
 import typing
 from pathlib import Path
 from typing import Optional
+from termcolor import colored
 
 if typing.TYPE_CHECKING:
     from robocorp.action_server._models import ActionPackage
@@ -43,7 +44,7 @@ def import_action_package(
     from ._models import ActionPackage
     from ._rcc import create_hash, get_rcc
 
-    log.info("Importing action package from: %s", action_package_dir)
+    log.debug("Importing action package from: %s", action_package_dir)
 
     datadir = datadir.absolute()
     import_path = Path(action_package_dir).absolute()
@@ -80,7 +81,7 @@ Note: no virtual environment will be used for the imported actions, they'll be r
         if not contents.get("dependencies"):
             raise ActionPackageError(f"{conda_yaml} has no 'dependencies' specified.")
 
-        log.info(
+        log.debug(
             f"""Actions added with managed environment defined by: {conda_yaml}."""
         )
 
@@ -122,7 +123,7 @@ Note: no virtual environment will be used for the imported actions, they'll be r
 
     python_exe = use_env.get("PYTHON_EXE")
     if python_exe:
-        log.info(f"Python interpreter path: {python_exe}")
+        log.info(colored(f"Python interpreter path: {python_exe}", attrs=["dark"]))
 
     action_package = ActionPackage(
         id=action_package_id,
@@ -131,7 +132,7 @@ Note: no virtual environment will be used for the imported actions, they'll be r
         conda_hash=condahash,
         env_json=json.dumps(use_env),
     )
-    log.info(f"Collecting actions for Action Package: {name}.")
+    log.debug(f"Collecting actions for Action Package: {name}.")
 
     env = build_python_launch_env(use_env)
     _add_actions_to_db(
@@ -285,7 +286,7 @@ def _add_actions_to_db(
 
         seen_action_ids = set()
         with db.transaction():
-            log.info("Updating action package: %s", action_package.name)
+            log.debug("Updating action package: %s", action_package.name)
             db.update_by_id(
                 ActionPackage,
                 existing_action_package.id,
@@ -301,7 +302,7 @@ def _add_actions_to_db(
                     # This is an existing action, we need to update it.
                     new_action_as_dict = asdict(action)
                     del new_action_as_dict["id"]
-                    log.info("Updating action: %s", action.name)
+                    log.debug("Updating action: %s", action.name)
                     db.update_by_id(Action, existing_action.id, new_action_as_dict)
                     seen_action_ids.add(existing_action.id)
                 else:

--- a/action_server/src/robocorp/action_server/_actions_process_pool.py
+++ b/action_server/src/robocorp/action_server/_actions_process_pool.py
@@ -8,6 +8,7 @@ import threading
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set
+from termcolor import colored
 
 from robocorp.action_server._models import Action, ActionPackage
 
@@ -160,7 +161,11 @@ class ProcessHandle:
                 if not line:
                     break
                 line = line.decode("utf-8", "replace")
-                print(f"output (pid: {pid}): {line.strip()}\n", end="")
+                print(
+                    colored(f"output (pid: {pid}): ", attrs=["dark"])
+                    + f"{line.strip()}\n",
+                    end="",
+                )
                 self._on_stderr(line)
 
         stderr = self._process.stderr

--- a/action_server/src/robocorp/action_server/_actions_run.py
+++ b/action_server/src/robocorp/action_server/_actions_run.py
@@ -6,6 +6,7 @@ import time
 import typing
 from typing import Annotated, Any, Dict, Optional
 
+from fastapi import HTTPException
 from fastapi.params import Header, Param
 from pydantic import BaseModel
 
@@ -239,7 +240,7 @@ def _run_action_in_thread(
 
             except BaseException as e:
                 _set_run_as_finished_failed(run, str(e), initial_time)
-                raise
+                raise HTTPException(status_code=500, detail=str(e))
 
 
 def _name_as_class_name(name):

--- a/action_server/src/robocorp/action_server/_robo_utils/log_custom_handler.py
+++ b/action_server/src/robocorp/action_server/_robo_utils/log_custom_handler.py
@@ -1,3 +1,4 @@
+import re
 import logging
 from contextlib import contextmanager
 

--- a/action_server/src/robocorp/action_server/_robo_utils/log_custom_handler.py
+++ b/action_server/src/robocorp/action_server/_robo_utils/log_custom_handler.py
@@ -1,4 +1,3 @@
-import re
 import logging
 from contextlib import contextmanager
 

--- a/action_server/src/robocorp/action_server/_robo_utils/log_formatter.py
+++ b/action_server/src/robocorp/action_server/_robo_utils/log_formatter.py
@@ -1,0 +1,10 @@
+import re
+from logging import Formatter
+
+
+class FormatterNoColor(Formatter):
+    strip_colors_regex = re.compile(r"(\x1b\[|\x9b)[0-?]*[ -/]*[@-~]")
+
+    def format(self, record):
+        message = super().format(record)
+        return self.strip_colors_regex.sub("", message)

--- a/action_server/src/robocorp/action_server/_robo_utils/log_formatter.py
+++ b/action_server/src/robocorp/action_server/_robo_utils/log_formatter.py
@@ -1,5 +1,8 @@
 import re
-from logging import Formatter
+from datetime import datetime
+from termcolor import colored
+from logging import Formatter, Filter
+from uvicorn.logging import AccessFormatter
 
 
 class FormatterNoColor(Formatter):
@@ -8,3 +11,32 @@ class FormatterNoColor(Formatter):
     def format(self, record):
         message = super().format(record)
         return self.strip_colors_regex.sub("", message)
+
+
+class FormatterStdout(Formatter):
+    def format(self, record):
+        if record.name.startswith("uvicorn"):
+            access_formatter = AccessFormatter()
+            (
+                client_addr,
+                method,
+                full_path,
+                http_version,
+                status_code,
+            ) = record.args
+
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            status_code = access_formatter.get_status_code(int(status_code))
+            return (
+                colored(f"{timestamp} - ", attrs=["dark"])
+                + colored(method, attrs=["bold"])
+                + f" {full_path} {status_code}"
+            )
+
+        return super().format(record)
+
+
+class UvicornLogFilter(Filter):
+    def filter(self, record):
+        # Log only Uvicorn Access messages
+        return not (record.name.startswith("uvicorn") and len(record.args) != 5)

--- a/action_server/src/robocorp/action_server/_selftest.py
+++ b/action_server/src/robocorp/action_server/_selftest.py
@@ -124,7 +124,7 @@ class ActionServerProcess:
             env["RC_ADD_SHUTDOWN_API"] = "1"
         process = self._process = Process(new_args, cwd=cwd, env=env)
 
-        compiled = re.compile(r"Action Server started at http://([\w.-]+):(\d+)")
+        compiled = re.compile(r"Action Server started at: http://([\w.-]+):(\d+)")
         future: Future[Tuple[str, str]] = Future()
 
         def collect_port_from_stdout(line):

--- a/action_server/src/robocorp/action_server/_selftest.py
+++ b/action_server/src/robocorp/action_server/_selftest.py
@@ -124,7 +124,7 @@ class ActionServerProcess:
             env["RC_ADD_SHUTDOWN_API"] = "1"
         process = self._process = Process(new_args, cwd=cwd, env=env)
 
-        compiled = re.compile(r"Action Server started at: http://([\w.-]+):(\d+)")
+        compiled = re.compile(r"Local Action Server: http://([\w.-]+):(\d+)")
         future: Future[Tuple[str, str]] = Future()
 
         def collect_port_from_stdout(line):

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -245,15 +245,17 @@ def start_server(
     def _on_started_message(self, **kwargs):
         (host, port) = _get_currrent_host()
 
+        padding_bottom = "" if (api_key or expose) else "\n"
         log.info(
             colored("\n  ⚡️ Action Server started at: ", "green", attrs=["bold"])
-            + colored(f"http://{settings.address}:{port}", "light_blue")
+            + colored(f"http://{settings.address}:{port}{padding_bottom}", "light_blue")
         )
 
         if api_key:
+            padding_bottom = "" if expose else "\n"
             log.info(
                 colored("  🔑 API Authorization key: ", attrs=["bold"])
-                + f'{{ "Authorization": "Bearer {api_key}"}}'
+                + f'{{ "Authorization": "Bearer {api_key}"}}{padding_bottom}'
             )
 
     async def _on_startup():

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -239,24 +239,30 @@ def start_server(
             settings.expose_url,
             settings.datadir,
             str(expose_session),
+            api_key,
         ]
         expose_subprocess = subprocess.Popen(args)
 
     def _on_started_message(self, **kwargs):
         (host, port) = _get_currrent_host()
 
-        padding_bottom = "" if (api_key or expose) else "\n"
         log.info(
-            colored("\n  ⚡️ Action Server started at: ", "green", attrs=["bold"])
-            + colored(f"http://{settings.address}:{port}{padding_bottom}", "light_blue")
+            colored("\n  ⚡️ Local Action Server: ", "green", attrs=["bold"])
+            + colored(f"http://{settings.address}:{port}", "light_blue")
         )
 
-        if api_key:
-            padding_bottom = "" if expose else "\n"
+        if not expose:
             log.info(
-                colored("  🔑 API Authorization key: ", attrs=["bold"])
-                + f'{{ "Authorization": "Bearer {api_key}"}}{padding_bottom}'
+                colored("     Public access: use ", attrs=["dark"])
+                + colored("--expose", attrs=["bold"])
+                + colored(" to expose\n", attrs=["dark"])
             )
+
+            if api_key:
+                log.info(
+                    colored("  🔑 API Authorization Bearer key: ", attrs=["bold"])
+                    + f"{api_key}\n"
+                )
 
     async def _on_startup():
         if expose:

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from functools import partial
 from typing import Dict, Optional
+from termcolor import colored
 
 log = logging.getLogger(__name__)
 
@@ -243,11 +244,16 @@ def start_server(
 
     def _on_started_message(self, **kwargs):
         (host, port) = _get_currrent_host()
-        log.info(f"\n  ⚡️ Action Server started at http://{settings.address}:{port}")
+
+        log.info(
+            colored("\n  ⚡️ Action Server started at: ", "green", attrs=["bold"])
+            + colored(f"http://{settings.address}:{port}", "light_blue")
+        )
 
         if api_key:
             log.info(
-                f'  🔑 API Authorization key: {{ "Authorization": "Bearer {api_key}"}}'
+                colored("  🔑 API Authorization key: ", attrs=["bold"])
+                + f'{{ "Authorization": "Bearer {api_key}"}}'
             )
 
     async def _on_startup():

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -115,13 +115,18 @@ async def handle_ping_pong(
 
 
 def handle_session_payload(
-    session_payload: SessionPayload, expose_url: str, datadir: str
+    session_payload: SessionPayload, expose_url: str, datadir: str, api_key: str | None
 ):
     url = f"https://{session_payload.sessionId}.{expose_url}"
     log.info(
         colored("  🌍 Public URL: ", "green", attrs=["bold"])
-        + colored(f"{url}\n", "light_blue")
+        + colored(f"{url}", "light_blue")
     )
+    if api_key:
+        log.info(
+            colored("  🔑 API Authorization Bearer key: ", attrs=["bold"])
+            + f"{api_key}\n"
+        )
     new_expose_session = get_expose_session(session_payload)
     write_expose_session_json(
         datadir=datadir,
@@ -156,6 +161,7 @@ async def expose_server(
     datadir: str,
     expose_session: str | None = None,
     ping_interval: int = 4,
+    api_key: str | None = None,
 ):
     """
     Exposes the server to the world.
@@ -203,7 +209,7 @@ async def expose_server(
                             try:
                                 session_payload = SessionPayload(**data)
                                 handle_session_payload(
-                                    session_payload, expose_url, datadir
+                                    session_payload, expose_url, datadir, api_key
                                 )
                             except ValidationError as e:
                                 if not session_payload:
@@ -238,7 +244,7 @@ async def expose_server(
     await task  # Wait for listen_for_requests to complete
 
 
-def main(parent_pid, port, verbose, host, expose_url, datadir, expose_session):
+def main(parent_pid, port, verbose, host, expose_url, datadir, expose_session, api_key):
     from robocorp.action_server._robo_utils.process import exit_when_pid_exists
 
     logging.basicConfig(
@@ -256,6 +262,7 @@ def main(parent_pid, port, verbose, host, expose_url, datadir, expose_session):
                 expose_url=expose_url,
                 datadir=datadir,
                 expose_session=expose_session if expose_session != "None" else None,
+                api_key=api_key,
             )
         )
     except KeyboardInterrupt:

--- a/action_server/src/robocorp/action_server/_server_expose.py
+++ b/action_server/src/robocorp/action_server/_server_expose.py
@@ -6,6 +6,7 @@ import os
 import sys
 import typing
 from typing import Optional
+from termcolor import colored
 
 import requests
 from pydantic import BaseModel, ValidationError
@@ -192,7 +193,11 @@ async def expose_server(
                                 url = (
                                     f"https://{session_payload.sessionId}.{expose_url}"
                                 )
-                                log.info(f"  🌍 Public URL: {url}\n")
+                                log.info(
+                                    colored("  🌍 Public URL: ", "green", attrs=["bold"])
+                                    + colored(f"{url}\n", "light_blue")
+                                )
+
                                 new_expose_session = get_expose_session(session_payload)
                                 write_expose_session_json(
                                     datadir=datadir,

--- a/action_server/src/robocorp/action_server/_server_websockets.py
+++ b/action_server/src/robocorp/action_server/_server_websockets.py
@@ -179,7 +179,7 @@ async def websocket_endpoint(websocket: WebSocket):
                     # just log it and ignore.
                     log.info('Ignoring additional call to "start_listen_run_events"')
     except WebSocketDisconnect:
-        log.info("Client disconnected from websocket.")
+        log.debug("Client disconnected from websocket.")
     except Exception:
         log.exception("Unexpected exception from websocket.")
     finally:

--- a/action_server/src/robocorp/action_server/_settings.py
+++ b/action_server/src/robocorp/action_server/_settings.py
@@ -132,7 +132,7 @@ class Settings:
             "host": self.address,
             "port": self.port,
             "reload": False,
-            "log_config": UVICORN_LOG_CONFIG,
+            "log_config": None,
         }
 
 
@@ -154,40 +154,3 @@ def get_settings() -> Settings:
     if _global_settings is None:
         raise AssertionError("It seems that the settings have not been setup yet.")
     return _global_settings
-
-
-UVICORN_LOG_CONFIG = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "access": {
-            "()": "uvicorn.logging.AccessFormatter",
-            "fmt": '%(asctime)s - "%(request_line)s" %(status_code)s',
-            "datefmt": "%Y-%m-%d %H:%M:%S",
-            "use_colors": True,
-        },
-        "default": {
-            "()": "uvicorn.logging.DefaultFormatter",
-            "fmt": "%(levelprefix)s %(asctime)s - %(message)s",
-            "datefmt": "%Y-%m-%d %H:%M:%S",
-            "use_colors": True,
-        },
-    },
-    "handlers": {
-        "access": {
-            "class": "logging.StreamHandler",
-            "formatter": "access",
-            "stream": "ext://sys.stdout",
-        },
-        "default": {
-            "formatter": "default",
-            "class": "logging.StreamHandler",
-            "stream": "ext://sys.stderr",
-        },
-    },
-    "loggers": {
-        "uvicorn": {"handlers": ["default"], "level": "DEBUG", "propagate": True},
-        "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
-        "uvicorn.error": {"level": "INFO", "propagate": False},
-    },
-}

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -371,6 +371,19 @@ def _main_retcode(args: Optional[list[str]], exit) -> int:
     parser = _create_parser()
     base_args = parser.parse_args(args)
 
+    # Log to stdout.
+    log_level = logging.DEBUG if base_args.verbose else logging.INFO
+
+    logger = logging.root
+    logger.setLevel(log_level)
+
+    _setup_stdout_logging(log_level)
+
+    log.info(
+        colored("\n  ⚡️ Starting Action Server ", attrs=["bold"])
+        + colored(f"v{__version__}\n", attrs=["dark"])
+    )
+
     command = base_args.command
     if not command:
         parser.print_help()
@@ -399,14 +412,6 @@ def _main_retcode(args: Optional[list[str]], exit) -> int:
     ):
         print(f"Unexpected command: {command}.", file=sys.stderr)
         return 1
-
-    # Log to stdout.
-    log_level = logging.DEBUG if base_args.verbose else logging.INFO
-
-    logger = logging.root
-    logger.setLevel(log_level)
-
-    _setup_stdout_logging(log_level)
 
     from ._settings import setup_settings
 

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -7,7 +7,11 @@ from typing import Optional, Union
 from termcolor import colored
 
 from . import __version__
-from ._robo_utils.log_formatter import FormatterNoColor
+from ._robo_utils.log_formatter import (
+    FormatterNoColor,
+    FormatterStdout,
+    UvicornLogFilter,
+)
 
 log = logging.getLogger(__name__)
 
@@ -317,7 +321,8 @@ def _setup_stdout_logging(log_level):
             "%(asctime)s [%(levelname)s] %(message)s", datefmt="[%Y-%m-%d %H:%M:%S]"
         )
     else:
-        formatter = logging.Formatter("%(message)s", datefmt="[%X]")
+        formatter = FormatterStdout("%(message)s", datefmt="[%X]")
+        stream_handler.addFilter(UvicornLogFilter())
 
     stream_handler.setFormatter(formatter)
     logger = logging.root

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -4,8 +4,10 @@ import os.path
 import sys
 from pathlib import Path
 from typing import Optional, Union
+from termcolor import colored
 
 from . import __version__
+from ._robo_utils.log_formatter import FormatterNoColor
 
 log = logging.getLogger(__name__)
 
@@ -310,6 +312,7 @@ def _setup_stdout_logging(log_level):
     stream_handler = StreamHandler()
     stream_handler.setLevel(log_level)
     if log_level == logging.DEBUG:
+        os.environ["NO_COLOR"] = "true"
         formatter = logging.Formatter(
             "%(asctime)s [%(levelname)s] %(message)s", datefmt="[%Y-%m-%d %H:%M:%S]"
         )
@@ -325,13 +328,13 @@ def _setup_logging(datadir: Path, log_level):
     from logging.handlers import RotatingFileHandler
 
     log_file = str(datadir / "server_log.txt")
-    log.info(f"Logs may be found at: {log_file}.")
+    log.info(colored(f"Logs may be found at: {log_file}.", attrs=["dark"]))
     rotating_handler = RotatingFileHandler(
         log_file, maxBytes=1_000_000, backupCount=3, encoding="utf-8"
     )
     rotating_handler.setLevel(log_level)
     rotating_handler.setFormatter(
-        logging.Formatter(
+        FormatterNoColor(
             "%(asctime)s [%(levelname)s] %(message)s", datefmt="[%Y-%m-%d %H:%M:%S]"
         )
     )
@@ -502,7 +505,7 @@ To migrate the database to the current version
                     elif command == "start":
                         # start imports the current directory by default
                         # (unless --actions-sync=false is specified).
-                        log.info("Synchronize actions: %s", base_args.actions_sync)
+                        log.debug("Synchronize actions: %s", base_args.actions_sync)
 
                         rcc.feedack_metric("action-server.started", __version__)
 
@@ -531,7 +534,13 @@ To migrate the database to the current version
                                 )
                                 if expose_session and not base_args.expose_allow_reuse:
                                     confirm = input(
-                                        f"Resume previous expose URL {expose_session.url} Y/N? [Y] "
+                                        colored(
+                                            "> Resume previous expose URL ",
+                                            attrs=["bold"],
+                                        )
+                                        + colored(expose_session.url, "light_blue")
+                                        + colored(" Y/N?", attrs=["bold"])
+                                        + colored(" [Y]", attrs=["dark"])
                                     )
                                     if confirm.lower() == "y" or confirm == "":
                                         log.debug("Resuming previous expose session")

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -371,18 +371,6 @@ def _main_retcode(args: Optional[list[str]], exit) -> int:
     parser = _create_parser()
     base_args = parser.parse_args(args)
 
-    # Log to stdout.
-    log_level = logging.DEBUG if base_args.verbose else logging.INFO
-
-    logger = logging.root
-    logger.setLevel(log_level)
-
-    _setup_stdout_logging(log_level)
-
-    log.info(
-        colored("\n  ⚡️ Starting Action Server ", attrs=["bold"])
-        + colored(f"v{__version__}\n", attrs=["dark"])
-    )
 
     command = base_args.command
     if not command:
@@ -412,6 +400,19 @@ def _main_retcode(args: Optional[list[str]], exit) -> int:
     ):
         print(f"Unexpected command: {command}.", file=sys.stderr)
         return 1
+    
+    # Log to stdout.
+    log_level = logging.DEBUG if base_args.verbose else logging.INFO
+
+    logger = logging.root
+    logger.setLevel(log_level)
+
+    _setup_stdout_logging(log_level)
+
+    log.info(
+        colored("\n  ⚡️ Starting Action Server ", attrs=["bold"])
+        + colored(f"v{__version__}\n", attrs=["dark"])
+    )
 
     from ._settings import setup_settings
 

--- a/action_server/src/robocorp/action_server/cli.py
+++ b/action_server/src/robocorp/action_server/cli.py
@@ -371,7 +371,6 @@ def _main_retcode(args: Optional[list[str]], exit) -> int:
     parser = _create_parser()
     base_args = parser.parse_args(args)
 
-
     command = base_args.command
     if not command:
         parser.print_help()
@@ -400,7 +399,7 @@ def _main_retcode(args: Optional[list[str]], exit) -> int:
     ):
         print(f"Unexpected command: {command}.", file=sys.stderr)
         return 1
-    
+
     # Log to stdout.
     log_level = logging.DEBUG if base_args.verbose else logging.INFO
 


### PR DESCRIPTION
A more lightweight approach by using [termcolor](https://pypi.org/project/termcolor/) library only to colorize and style terminal output:
- The colors are disabled when the log level is `DEBUG`. The [NO_COLOR](https://no-color.org) env variable is also respected
- The ANSI codes are striped from the `RotatingFileHandler` file logs
- Mark some of startup messages as `debug` level since they do give less useful information to the user (e.g. logging current yaml file path or websocket connection state to the UI)
- Highlight Action Server URLs as the most important startup information
- Update uvicorn request formatting to display a timestamp also

<img width="1257" alt="image" src="https://github.com/robocorp/robocorp/assets/31288628/c38d63d5-d5f2-4f00-9835-30670bd53683">

- Update `_run_action_in_thread` to fail with an `HTTPException` instead of the original error so the endpoint fails correctly with 500 error and action server does not show the error traceback to `_run_action_in_thread` which gives no useful information to the user:
<img width="1254" alt="image" src="https://github.com/robocorp/robocorp/assets/31288628/cbd2aade-7a2d-4019-8c2b-2244d7d40b6c">


