### PR TITLE
Updated Action Server --controller arg for RCC

### DIFF
--- a/action_server/src/robocorp/action_server/_rcc.py
+++ b/action_server/src/robocorp/action_server/_rcc.py
@@ -67,7 +67,7 @@ class Rcc(object):
 
         kwargs: dict = build_subprocess_kwargs(cwd, env, stderr=stderr)
         rcc_location = str(self._rcc_location)
-        args = [rcc_location] + args + ["--controller", "ActionServer"]
+        args = [rcc_location] + args + ["--controller", "action-server"]
         return args, kwargs
 
     def _run_rcc(


### PR DESCRIPTION
The naming conventions get tricky if we have multiples, lower-case + dashes, for these.
Need someone to check if there are other places where Action Server sets the `--controller` -arg for RCC calls.