### PR TITLE
Readme add video link and anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Looking for a replacement to RPA? Head over to our [Enterprise Python Automation
 
 ---
 
-<h1 id="quickstart">🏃‍♂️ Quickstart</h1>
+<div id="quickstart"/>
+# 🏃‍♂️ Quickstart
 
 Install Robocorp Action Server:
 
@@ -85,7 +86,8 @@ Head over to [Action Server docs](./action_server/README.md) for more.
 
 ---
 
-# What makes a Python function an ⚡️Action?
+<div id="python-action"/>
+# What makes a Python function an⚡️Action?
 
 1️⃣ `conda.yaml` file that sets up your **Python environment and dependencies**:
 
@@ -141,6 +143,7 @@ def greeting(name: str) -> str:
 
 ---
 
+<div id="connect-gpt"/>
 ## Connect with OpenAI GPTs Actions
 
 Once you have started the Action Server with `--expose` flag, you’ll get a URL available to the public, along with the authentication token. The relevant part of the output from the terminal looks like this, of course with your own details:
@@ -163,7 +166,7 @@ Adding the Action Server hosted AI Action to your custom GPT is super simple, ba
 > **TIP:**<br/>
 > Use `@action(is_consequential=False)` flag to avoid user needing to accept the action execution separately each time on your GPT.
 
-
+<div id="langchain"/>
 ## Add Action Server as a Toolkit to [🦜️🔗 LangChain](https://github.com/robocorp/langchain)
 
 Robocorp Action Server comes with everything needed to connect it to your Langchain AI app project. The easiest way is to start with the template, provided in the Langchain project. Here’s how to do it:
@@ -204,6 +207,7 @@ tools = toolkit.get_tools()
 
 ---
 
+<div id="why-actions"/>
 ## Why use Robocorp AI Actions
 
 - ❤️ “when it comes to automation, the Robocorp suite is the best one” _[/u/disturbing_nickname](https://old.reddit.com/r/rpa/comments/18qqspn/codeonly_rpa_pet_project/kez2jds/?context=3)_
@@ -218,6 +222,7 @@ Robocorp stack is hands down the easiest way to give AI agents more capabilities
 - 🤯 **No-pain Python environment management** - Don't do [this](https://xkcd.com/1987/). Robocorp manages a full Python environment for your actions with ease.
 - 🚀 **Deploy with zero config and infra** - One step deployment, and you'll be connecting your `@action` to AI apps like Langchain and OpenAI GPTs in seconds.
 
+<div id="langchain"/>
 ## Inspo
 
 Check out these example projects for inspiration.
@@ -229,6 +234,7 @@ Check out these example projects for inspiration.
 
 Build more `@actions` and be awesome! We'd love to hear and see what have you built. Join our [Slack community](https://robocorp-developers.slack.com/) to share your work, or post it in the [Discussions](https://github.com/robocorp/robocorp/discussions/categories/show-and-tell). We'll soon start showcasing the best from the community here!
 
+<div id="roadmap"/>
 ## Roadmap
 
 - [x] Action Server `brew install` for Mac users
@@ -244,6 +250,7 @@ Build more `@actions` and be awesome! We'd love to hear and see what have you bu
 - [ ] Explicit action user approval
 - [ ] Stateful actions
 
+<div id="contribute"/>
 ## Contributing and issues
 
 > ⭐️ First, please star the repo - your support is highly appreciated!

--- a/README.md
+++ b/README.md
@@ -20,16 +20,6 @@ Robocorp Action Server makes your Python scripts compatible with ChatGPT and Lan
 </picture>
 
 
-
-<p align="center">
-  <a href="https://www.youtube.com/watch?v=7aq6QDCaUmA">
-    <img src="https://img.youtube.com/vi/7aq6QDCaUmA/0.jpg" alt="AI Actions Example">
-  </a>
-  <br/>
-  👆 AI Actions Example video in Youtube
-</p>
-<br/>
-
 Looking for a replacement to RPA? Head over to our [Enterprise Python Automation site](https://robocorp.com/docs/quickstart-guide) for more.
 
 ---
@@ -162,9 +152,15 @@ Uvicorn running on http://localhost:8080 (Press CTRL+C to quit)
 🔑 Add following header api authorization header to run actions: { "Authorization": "Bearer xxx_xxx" }
 ```
 
+<h3 id="actions-video" align="center">
+  <a href="https://www.youtube.com/watch?v=7aq6QDCaUmA">
+    👉 Example video in Youtube 👈
+  </a>
+</h3>
+
 Adding the Action Server hosted AI Action to your custom GPT is super simple, basically just navigate to “Actions” section of the GPT configuration, add the link to import the actions, and **Add Authentication** with **Authentication method** set to _“API key”_ and **Auth Type** to _“Bearer”_.
 
-> [!TIP]
+> **TIP:**<br/>
 > Use `@action(is_consequential=False)` flag to avoid user needing to accept the action execution separately each time on your GPT.
 
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ Robocorp Action Server makes your Python scripts compatible with ChatGPT and Lan
 </picture>
 
 
-👉 **Checkout the example video**
+
 <p align="center">
   <a href="https://www.youtube.com/watch?v=7aq6QDCaUmA" target="_blank">
     <img src="https://img.youtube.com/vi/7aq6QDCaUmA/0.jpg" alt="AI Actions Example">
   </a>
+  <br/>
+  👉 AI Actions Example video in Youtube
 </p>
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Looking for a replacement to RPA? Head over to our [Enterprise Python Automation
 
 ---
 
-<div id="quickstart"/>
+<div id="quickstart"></div>
+
 # 🏃‍♂️ Quickstart
 
 Install Robocorp Action Server:
@@ -86,7 +87,8 @@ Head over to [Action Server docs](./action_server/README.md) for more.
 
 ---
 
-<div id="python-action"/>
+<div id="python-action"></div>
+
 # What makes a Python function an⚡️Action?
 
 1️⃣ `conda.yaml` file that sets up your **Python environment and dependencies**:
@@ -143,7 +145,8 @@ def greeting(name: str) -> str:
 
 ---
 
-<div id="connect-gpt"/>
+<div id="connect-gpt"></div>
+
 ## Connect with OpenAI GPTs Actions
 
 Once you have started the Action Server with `--expose` flag, you’ll get a URL available to the public, along with the authentication token. The relevant part of the output from the terminal looks like this, of course with your own details:
@@ -166,7 +169,8 @@ Adding the Action Server hosted AI Action to your custom GPT is super simple, ba
 > **TIP:**<br/>
 > Use `@action(is_consequential=False)` flag to avoid user needing to accept the action execution separately each time on your GPT.
 
-<div id="langchain"/>
+<div id="langchain"></div>
+
 ## Add Action Server as a Toolkit to [🦜️🔗 LangChain](https://github.com/robocorp/langchain)
 
 Robocorp Action Server comes with everything needed to connect it to your Langchain AI app project. The easiest way is to start with the template, provided in the Langchain project. Here’s how to do it:
@@ -207,7 +211,8 @@ tools = toolkit.get_tools()
 
 ---
 
-<div id="why-actions"/>
+<div id="why-actions"></div>
+
 ## Why use Robocorp AI Actions
 
 - ❤️ “when it comes to automation, the Robocorp suite is the best one” _[/u/disturbing_nickname](https://old.reddit.com/r/rpa/comments/18qqspn/codeonly_rpa_pet_project/kez2jds/?context=3)_
@@ -222,7 +227,8 @@ Robocorp stack is hands down the easiest way to give AI agents more capabilities
 - 🤯 **No-pain Python environment management** - Don't do [this](https://xkcd.com/1987/). Robocorp manages a full Python environment for your actions with ease.
 - 🚀 **Deploy with zero config and infra** - One step deployment, and you'll be connecting your `@action` to AI apps like Langchain and OpenAI GPTs in seconds.
 
-<div id="inspiration"/>
+<div id="inspiration"></div>
+
 ## Inspiration
 
 Check out these example projects for inspiration.
@@ -234,7 +240,8 @@ Check out these example projects for inspiration.
 
 Build more `@actions` and be awesome! We'd love to hear and see what have you built. Join our [Slack community](https://robocorp-developers.slack.com/) to share your work, or post it in the [Discussions](https://github.com/robocorp/robocorp/discussions/categories/show-and-tell). We'll soon start showcasing the best from the community here!
 
-<div id="roadmap"/>
+<div id="roadmap"></div>
+
 ## Roadmap
 
 - [x] Action Server `brew install` for Mac users
@@ -250,7 +257,8 @@ Build more `@actions` and be awesome! We'd love to hear and see what have you bu
 - [ ] Explicit action user approval
 - [ ] Stateful actions
 
-<div id="contribute"/>
+<div id="contribute"></div>
+
 ## Contributing and issues
 
 > ⭐️ First, please star the repo - your support is highly appreciated!

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Robocorp Action Server makes your Python scripts compatible with ChatGPT and Lan
 
 👉 **Checkout the example video**
 <p align="center">
-  <a href="https://www.youtube.com/watch?v=7aq6QDCaUmA">
+  <a href="https://www.youtube.com/watch?v=7aq6QDCaUmA" target="_blank">
     <img src="https://img.youtube.com/vi/7aq6QDCaUmA/0.jpg" alt="AI Actions Example">
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ Robocorp Action Server makes your Python scripts compatible with ChatGPT and Lan
 
 👉 **Checkout the example video**
 
-<div style="text-align: center;">
-  [![Example](https://img.youtube.com/vi/7aq6QDCaUmA/0.jpg)](https://www.youtube.com/watch?v=7aq6QDCaUmA)
-</div>
+[![Example](https://img.youtube.com/vi/7aq6QDCaUmA/0.jpg)](https://www.youtube.com/watch?v=7aq6QDCaUmA)
 <br/>
 
 Looking for a replacement to RPA? Head over to our [Enterprise Python Automation site](https://robocorp.com/docs/quickstart-guide) for more.

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ Robocorp stack is hands down the easiest way to give AI agents more capabilities
 - 🤯 **No-pain Python environment management** - Don't do [this](https://xkcd.com/1987/). Robocorp manages a full Python environment for your actions with ease.
 - 🚀 **Deploy with zero config and infra** - One step deployment, and you'll be connecting your `@action` to AI apps like Langchain and OpenAI GPTs in seconds.
 
-<div id="langchain"/>
-## Inspo
+<div id="inspiration"/>
+## Inspiration
 
 Check out these example projects for inspiration.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Robocorp Action Server makes your Python scripts compatible with ChatGPT and Lan
 
 
 <p align="center">
-  <a href="https://www.youtube.com/watch?v=7aq6QDCaUmA" target="_blank">
+  <a href="https://www.youtube.com/watch?v=7aq6QDCaUmA">
     <img src="https://img.youtube.com/vi/7aq6QDCaUmA/0.jpg" alt="AI Actions Example">
   </a>
   <br/>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Robocorp Action Server makes your Python scripts compatible with ChatGPT and Lan
   <img alt="Text changing depending on mode. Light: 'So light!' Dark: 'So dark!'" src="./docs/include/robocorp-flow-light.webp">
 </picture>
 
+
+👉 **Checkout the example video**
+
+<div style="text-align: center;">
+  [![Example](https://img.youtube.com/vi/7aq6QDCaUmA/0.jpg)](https://www.youtube.com/watch?v=7aq6QDCaUmA)
+</div>
+<br/>
+
 Looking for a replacement to RPA? Head over to our [Enterprise Python Automation site](https://robocorp.com/docs/quickstart-guide) for more.
 
 ---

--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ Robocorp Action Server makes your Python scripts compatible with ChatGPT and Lan
 
 
 👉 **Checkout the example video**
-
-[![Example](https://img.youtube.com/vi/7aq6QDCaUmA/0.jpg)](https://www.youtube.com/watch?v=7aq6QDCaUmA)
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=7aq6QDCaUmA">
+    <img src="https://img.youtube.com/vi/7aq6QDCaUmA/0.jpg" alt="AI Actions Example">
+  </a>
+</p>
 <br/>
 
 Looking for a replacement to RPA? Head over to our [Enterprise Python Automation site](https://robocorp.com/docs/quickstart-guide) for more.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Robocorp Action Server makes your Python scripts compatible with ChatGPT and Lan
     <img src="https://img.youtube.com/vi/7aq6QDCaUmA/0.jpg" alt="AI Actions Example">
   </a>
   <br/>
-  👉 AI Actions Example video in Youtube
+  👆 AI Actions Example video in Youtube
 </p>
 <br/>
 


### PR DESCRIPTION
https://github.com/robocorp/robocorp/blob/readme-add-video/README.md

I put it right after the first picture. Playing the video directly and opening to another tab are both restricted by GitHub sanitizers, so the video jumps the current tab to youtube.

Added anchors to headings in main readme:
https://github.com/robocorp/robocorp/tree/readme-add-video#quickstart
https://github.com/robocorp/robocorp/tree/readme-add-video#python-action
https://github.com/robocorp/robocorp/tree/readme-add-video#connect-gpt
https://github.com/robocorp/robocorp/tree/readme-add-video#langchain
https://github.com/robocorp/robocorp/tree/readme-add-video#why-actions
https://github.com/robocorp/robocorp/tree/readme-add-video#inspiration
https://github.com/robocorp/robocorp/tree/readme-add-video#roadmap
https://github.com/robocorp/robocorp/tree/readme-add-video#contribute