### PR TITLE
Outputs creation should support Path-like objects for files param

### DIFF
--- a/workitems/docs/CHANGELOG.md
+++ b/workitems/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Outputs creation supports Path-like objects for files param
+
 ## 1.4.3 - 2024-02-07
 
 - Support for retrieving the error through the `exception` property of a failed input

--- a/workitems/docs/api/robocorp.workitems.md
+++ b/workitems/docs/api/robocorp.workitems.md
@@ -13,7 +13,7 @@ ______________________________________________________________________
 
 ## class `Inputs`
 
-**Source:** [`__init__.py:65`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/__init__.py#L65)
+**Source:** [`__init__.py:66`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/__init__.py#L66)
 
 Inputs represents the input queue of work items.
 
@@ -31,7 +31,7 @@ ______________________________________________________________________
 
 ### method `reserve`
 
-**Source:** [`__init__.py:98`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/__init__.py#L98)
+**Source:** [`__init__.py:99`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/__init__.py#L99)
 
 ```python
 reserve() → Input
@@ -53,7 +53,7 @@ ______________________________________________________________________
 
 ## class `Outputs`
 
-**Source:** [`__init__.py:113`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/__init__.py#L113)
+**Source:** [`__init__.py:114`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/__init__.py#L114)
 
 Outputs represents the output queue of work items.
 
@@ -67,12 +67,12 @@ ______________________________________________________________________
 
 ### method `create`
 
-**Source:** [`__init__.py:139`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/__init__.py#L139)
+**Source:** [`__init__.py:140`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/__init__.py#L140)
 
 ```python
 create(
     payload: Optional[dict[str, Any], list[Any], str, int, float, bool] = None,
-    files: Optional[str, list[str]] = None,
+    files: Optional[Path, str, list[Union[Path, str]]] = None,
     save: bool = True
 ) → Output
 ```
@@ -178,7 +178,7 @@ ______________________________________________________________________
 **Source:** [`_workitem.py:145`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/_workitem.py#L145)
 
 ```python
-add_files(pattern: str) → list[Path]
+add_files(pattern: Union[Path, str]) → list[Path]
 ```
 
 Attach files from the local machine to the work item that match the given pattern.
@@ -292,7 +292,7 @@ ______________________________________________________________________
 **Source:** [`_workitem.py:402`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/_workitem.py#L402)
 
 ```python
-get_files(pattern: str, path: Optional[Path] = None) → list[Path]
+get_files(pattern: str, path: Optional[Path, str] = None) → list[Path]
 ```
 
 Download all files attached to this work item that match the given pattern.
@@ -444,7 +444,7 @@ ______________________________________________________________________
 **Source:** [`_workitem.py:145`](https://github.com/robocorp/robocorp/tree/master/workitems/src/robocorp/workitems/_workitem.py#L145)
 
 ```python
-add_files(pattern: str) → list[Path]
+add_files(pattern: Union[Path, str]) → list[Path]
 ```
 
 Attach files from the local machine to the work item that match the given pattern.

--- a/workitems/poetry.lock
+++ b/workitems/poetry.lock
@@ -788,6 +788,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -795,8 +796,16 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -813,6 +822,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -820,6 +830,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1045,13 +1056,13 @@ files = [
 
 [[package]]
 name = "types-requests"
-version = "2.31.0.20240125"
+version = "2.31.0.20240218"
 description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-requests-2.31.0.20240125.tar.gz", hash = "sha256:03a28ce1d7cd54199148e043b2079cdded22d6795d19a2c2a6791a4b2b5e2eb5"},
-    {file = "types_requests-2.31.0.20240125-py3-none-any.whl", hash = "sha256:9592a9a4cb92d6d75d9b491a41477272b710e021011a2a3061157e2fb1f1a5d1"},
+    {file = "types-requests-2.31.0.20240218.tar.gz", hash = "sha256:f1721dba8385958f504a5386240b92de4734e047a08a40751c1654d1ac3349c5"},
+    {file = "types_requests-2.31.0.20240218-py3-none-any.whl", hash = "sha256:a82807ec6ddce8f00fe0e949da6d6bc1fbf1715420218a9640d695f70a9e5a9b"},
 ]
 
 [package.dependencies]
@@ -1059,13 +1070,13 @@ urllib3 = ">=2"
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.10.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
-    {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
+    {file = "typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"},
+    {file = "typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"},
 ]
 
 [[package]]
@@ -1085,13 +1096,13 @@ typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "uc-micro-py"
-version = "1.0.2"
+version = "1.0.3"
 description = "Micro subset of unicode data files for linkify-it-py projects."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "uc-micro-py-1.0.2.tar.gz", hash = "sha256:30ae2ac9c49f39ac6dce743bd187fcd2b574b16ca095fa74cd9396795c954c54"},
-    {file = "uc_micro_py-1.0.2-py3-none-any.whl", hash = "sha256:8c9110c309db9d9e87302e2f4ad2c3152770930d88ab385cd544e7a7e75f3de0"},
+    {file = "uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a"},
+    {file = "uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5"},
 ]
 
 [package.extras]
@@ -1099,13 +1110,13 @@ test = ["coverage", "pytest", "pytest-cov"]
 
 [[package]]
 name = "urllib3"
-version = "2.2.0"
+version = "2.2.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.0-py3-none-any.whl", hash = "sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"},
-    {file = "urllib3-2.2.0.tar.gz", hash = "sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"},
+    {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
+    {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
 ]
 
 [package.extras]

--- a/workitems/src/robocorp/workitems/__init__.py
+++ b/workitems/src/robocorp/workitems/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Callable, Optional, Union, cast
 
 from robocorp.tasks import get_current_task, task_cache
@@ -161,7 +162,7 @@ class Outputs:
             item.payload = payload
 
         if files is not None:
-            if isinstance(files, str):
+            if isinstance(files, (Path, str)):
                 item.add_files(pattern=files)
             else:
                 for path in files:

--- a/workitems/src/robocorp/workitems/__init__.py
+++ b/workitems/src/robocorp/workitems/__init__.py
@@ -11,7 +11,7 @@ from ._exceptions import (
     EmptyQueue,
     to_exception_type,
 )
-from ._types import ExceptionType, JSONType, State
+from ._types import ExceptionType, JSONType, PathType, State
 from ._workitem import Input, Output
 
 __version__ = "1.4.3"
@@ -139,7 +139,7 @@ class Outputs:
     def create(
         self,
         payload: Optional[JSONType] = None,
-        files: Optional[Union[str, list[str]]] = None,
+        files: Optional[Union[PathType, list[PathType]]] = None,
         save: bool = True,
     ) -> Output:
         """Create a new output work item, which can have both a JSON

--- a/workitems/src/robocorp/workitems/_workitem.py
+++ b/workitems/src/robocorp/workitems/_workitem.py
@@ -142,7 +142,7 @@ class WorkItem:
 
         return path
 
-    def add_files(self, pattern: str) -> list[Path]:
+    def add_files(self, pattern: PathType) -> list[Path]:
         """Attach files from the local machine to the work item that
         match the given pattern.
 
@@ -154,7 +154,7 @@ class WorkItem:
         Returns:
             List of added paths
         """
-        matches = glob(pattern, recursive=False)
+        matches = glob(str(pattern), recursive=False)
 
         paths = []
         for match in matches:

--- a/workitems/src/robocorp/workitems/_workitem.py
+++ b/workitems/src/robocorp/workitems/_workitem.py
@@ -115,7 +115,7 @@ class WorkItem:
         self._files_to_remove = set()
         self._saved = True
 
-    def add_file(self, path: Union[Path, str], name: Optional[str] = None) -> Path:
+    def add_file(self, path: PathType, name: Optional[str] = None) -> Path:
         """Attach a file from the local machine to the work item.
 
         Note: Files are not uploaded until the item is saved.
@@ -399,7 +399,7 @@ class Input(WorkItem):
 
         return path.absolute()
 
-    def get_files(self, pattern: str, path: Optional[Path] = None) -> list[Path]:
+    def get_files(self, pattern: str, path: Optional[PathType] = None) -> list[Path]:
         """Download all files attached to this work item that match
         the given pattern.
 


### PR DESCRIPTION
Include `Path`-like objects for files param in outputs creation and methods that use it.