### PR TITLE
Make get_win_version a static method

### DIFF
--- a/windows/docs/CHANGELOG.md
+++ b/windows/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Make get_win_version a static method on Desktop
+- Make `get_win_version` a static method of `windows.Desktop` for easier usage.
 
 ## 1.0.2 - 2024-02-01
 

--- a/windows/docs/CHANGELOG.md
+++ b/windows/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Make get_win_version a static method on Desktop
+
 ## 1.0.2 - 2024-02-01
 
 - Notice in the docs about the need to include `robocorp-windows` dependency in order

--- a/windows/src/robocorp/windows/_desktop.py
+++ b/windows/src/robocorp/windows/_desktop.py
@@ -355,7 +355,8 @@ class Desktop(ControlElement):
         self.send_keys("{Enter}")
         time.sleep(wait_time)
 
-    def get_win_version(self) -> str:
+    @staticmethod
+    def get_win_version() -> str:
         """
         Windows only utility which returns the current Windows major version.
 
@@ -366,10 +367,15 @@ class Desktop(ControlElement):
         #  number. (the same applies for `platform.version()`)
         import platform
 
+        WINDOWS_11_BUILD = 22000
+        WINDOWS_10 = "10"
+        WINDOWS_11 = "11"
+
         version_parts = platform.version().split(".")
         major = version_parts[0]
-        if major == "10" and int(version_parts[2]) >= 22000:
-            major = "11"
+
+        if major == WINDOWS_10 and int(version_parts[2]) >= WINDOWS_11_BUILD:
+            major = WINDOWS_11
 
         return major
 


### PR DESCRIPTION
Make `get_win_version` a static method so it can be used more like an utilitary where needed.
Avoid redefinitions like [windows-calc-notepad](https://github.com/robocorp/example-windows-calc-notepad/blob/master/tasks.py#L32) example.