### PR TITLE
Whitelist actions, get package name from package.yaml and slugify package and action names in urls.

### DIFF
--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- The action package name is now gotten from the `package.yaml` and not from the directory name
+  (it's still gotten from the directory name when `conda.yaml` is used for backward compatibility).
+  
+- The action package name and action name are slugified to be ascii only and replace
+  unwanted chars for `-` in the urls.
+  
+- A `--whitelist` argument is accepted in the command line for `start` and `import` and
+  it allows whitelisting action package names as well as action names. 
+
 ## 0.0.27 - 2024-03-04
 
 - Same as 0.0.26, but had issues publishing the actual binary.

--- a/action_server/docs/guides/03-whitelist-on-start-or-import.md
+++ b/action_server/docs/guides/03-whitelist-on-start-or-import.md
@@ -1,0 +1,52 @@
+# Whitelisting actions to be run
+
+There are 2 situations where one can whitelist the actions which should
+be used, at import and at server start time.
+
+This can be specified in the `--whitelist` command line parameter.
+
+## Whitelist argument spec
+
+- The format of the whitelist is flexible so that it accepts the format
+  accepted by [fnmatch](https://docs.python.org/3/library/fnmatch.html).
+
+- The package name can potentially be matched too (if `/` is added the package
+  name is matched, otherwise just the action name is matched).
+
+- It's possible to specify multiple actions by separating them with a comma.
+
+- `-` and `_` may be used interchangeably. 
+
+## Examples
+
+`--whitelist "action-1,action_2"`
+
+`--whitelist "package1/action*1,package2/action*2"`
+
+`--whitelist "*foo/sheet,*bar/sheet"`
+
+`--whitelist "*foo/*"`
+
+### Importing actions
+
+When actions are imported, it's possible to whitelist which actions should
+actually be imported.
+
+Example:
+
+```
+action-server import --datadir=<path to datadir> --whitelist my_action1,my_action2
+action-server start --actions-sync=false --datadir=<path to datadir>
+```
+
+
+### Serving actions
+
+When actions are served, it's possible to whitelist which actions should
+actually be available to run.
+
+Example:
+
+```
+action-server start --datadir=<path to datadir> --whitelist my_action1,my_action2
+```

--- a/action_server/src/robocorp/action_server/_protocols.py
+++ b/action_server/src/robocorp/action_server/_protocols.py
@@ -1,5 +1,14 @@
 from enum import Enum
-from typing import Any, Generic, Optional, TypedDict, TypeVar
+from typing import (
+    Any,
+    Generic,
+    Literal,
+    Optional,
+    Protocol,
+    Sequence,
+    TypedDict,
+    TypeVar,
+)
 
 T = TypeVar("T")
 
@@ -72,3 +81,45 @@ def check_implements(x: T) -> T:
     Mypy should complain if `self` is not implementing the IExpectedProtocol.
     """
     return x
+
+
+class ArgumentsNamespace(Protocol):
+    """
+    This is the argparse.Namespace with the arguments provided by the user.
+    """
+
+    command: Literal["download-rcc", "package", "import", "start", "version"]
+    verbose: bool
+    db_file: str
+    datadir: str
+
+
+class ArgumentsNamespaceDownloadRcc(ArgumentsNamespace):
+    command: Literal["download-rcc"]
+    file: str
+
+
+class ArgumentsNamespacePackage(ArgumentsNamespace):
+    command: Literal["package"]
+    update: bool
+    dry_run: bool
+    no_backup: bool
+
+
+class ArgumentsNamespaceBaseImportOrStart(ArgumentsNamespace):
+    command: Literal["import", "start"]
+    dir: Sequence[str]
+    skip_lint: bool
+    whitelist: str
+
+
+class ArgumentsNamespaceImport(ArgumentsNamespaceBaseImportOrStart):
+    command: Literal["import"]
+
+
+class ArgumentsNamespaceStart(ArgumentsNamespaceBaseImportOrStart):
+    command: Literal["start"]
+    actions_sync: bool
+    expose: bool
+    expose_allow_reuse: bool
+    api_key: str

--- a/action_server/src/robocorp/action_server/_selftest.py
+++ b/action_server/src/robocorp/action_server/_selftest.py
@@ -3,6 +3,7 @@ This module contains utilities for testing and to do a 'selftest' of the
 executable even in release mode.
 """
 
+import json
 import os
 import re
 import subprocess
@@ -203,8 +204,6 @@ class ActionServerClient:
         return self.get_str("openapi.json")
 
     def get_json(self, url, params: Optional[dict] = None):
-        import json
-
         contents = self.get_str(url, params=params)
         try:
             return json.loads(contents)
@@ -384,8 +383,12 @@ def check_new_template(
         if verbose:
             print("Using post to call action.")
 
+        # open_api = client.get_openapi_json()
+        # decoded = json.loads(open_api)
+        # print(json.dumps(decoded, indent=4))
+
         found = client.post_get_str(
-            "/api/actions/my-project/compare-time-zones/run",
+            "/api/actions/package-name/compare-time-zones/run",
             {
                 "user_timezone": "Europe/Helsinki",
                 "compare_to_timezones": "America/New_York, Asia/Kolkata",

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -17,7 +17,9 @@ def _name_as_summary(name):
 
 
 def _name_to_url(name):
-    return name.replace("_", "-")
+    from robocorp.action_server._slugify import slugify
+
+    return slugify(name.replace("_", "-"))
 
 
 def get_action_description_from_docs(docs: str) -> str:

--- a/action_server/src/robocorp/action_server/_settings.py
+++ b/action_server/src/robocorp/action_server/_settings.py
@@ -8,6 +8,8 @@ from typing import Iterator, Optional
 
 from termcolor import colored
 
+from ._protocols import ArgumentsNamespace
+
 log = logging.getLogger(__name__)
 
 
@@ -83,7 +85,7 @@ class Settings:
         return ret
 
     @classmethod
-    def create(cls, args) -> "Settings":
+    def create(cls, args: ArgumentsNamespace) -> "Settings":
         user_specified_datadir = args.datadir
         if not user_specified_datadir:
             import hashlib
@@ -144,7 +146,7 @@ _global_settings: Optional[Settings] = None
 
 
 @contextmanager
-def setup_settings(args) -> Iterator[Settings]:
+def setup_settings(args: ArgumentsNamespace) -> Iterator[Settings]:
     global _global_settings
     settings = Settings.create(args)
     _global_settings = settings

--- a/action_server/src/robocorp/action_server/_slugify.py
+++ b/action_server/src/robocorp/action_server/_slugify.py
@@ -1,0 +1,40 @@
+# Original work Copyright (c) Django Software Foundation and individual contributors (BSD 3-Clause "New" or "Revised" License)
+# All modifications Copyright (c) Robocorp Technologies Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http: // www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Module based on: https://github.com/django/django/blob/main/django/utils/text.py
+import re
+import unicodedata
+
+
+def slugify(value: str, allow_unicode: bool = False) -> str:
+    """
+    Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
+    dashes to single dashes. Remove characters that aren't alphanumerics,
+    underscores, or hyphens. Convert to lowercase. Also strip leading and
+    trailing whitespace, dashes, and underscores.
+    """
+    if allow_unicode:
+        value = unicodedata.normalize("NFKC", value)
+    else:
+        value = _remove_accents(value).encode("ascii", "ignore").decode("ascii")
+
+    value = re.sub(r"[^\w\s-]", "", value.lower())
+    return re.sub(r"[-\s]+", "-", value).strip("-_")
+
+
+def _remove_accents(input_str):
+    nfkd_form = unicodedata.normalize("NFKD", input_str)
+    return "".join([c for c in nfkd_form if not unicodedata.combining(c)])

--- a/action_server/src/robocorp/action_server/_whitelist.py
+++ b/action_server/src/robocorp/action_server/_whitelist.py
@@ -1,0 +1,70 @@
+import fnmatch
+
+
+def normalize_name(name):
+    """
+    Normalizes action names to handle hyphens and underscores interchangeably.
+    """
+    return name.replace("-", "_").strip()
+
+
+def accept_action(pattern: str, package_name: str, action_name: str) -> bool:
+    """
+    Determines whether an action should be accepted based on the whitelist pattern.
+
+    Args:
+      pattern: The whitelist pattern to match against.
+      package_name: The name of the package containing the action (can be empty).
+      action_name: The name of the action.
+
+    Returns:
+      True if the action matches the whitelist pattern, False otherwise.
+    """
+    package_name = normalize_name(package_name)
+    action_name = normalize_name(action_name)
+    pattern = normalize_name(pattern)
+
+    for single_pattern in pattern.split(","):
+        # Check if the pattern includes a package name separated by '/'
+        if "/" in single_pattern:
+            package_pattern, action_pattern = single_pattern.split("/", 1)
+        else:
+            package_pattern = "*"
+            action_pattern = single_pattern
+
+        # Check if the package name matches the package pattern (if provided)
+        if fnmatch.fnmatch(package_name, package_pattern):
+            # Match the action name against the action pattern
+            if fnmatch.fnmatch(action_name, action_pattern):
+                return True
+
+    return False
+
+
+def accept_action_package(pattern: str, package_name: str) -> bool:
+    """
+    Determines whether an action package should be accepted based on the whitelist pattern.
+
+    Args:
+      pattern: The whitelist pattern to match against.
+      package_name: The name of the package containing the action (can be empty).
+      action_name: The name of the action.
+
+    Returns:
+      True if the action matches the whitelist pattern, False otherwise.
+    """
+    package_name = normalize_name(package_name)
+    pattern = normalize_name(pattern)
+
+    for single_pattern in pattern.split(","):
+        # Check if the pattern includes a package name separated by '/'
+        if "/" in single_pattern:
+            package_pattern, _action_pattern = single_pattern.split("/", 1)
+        else:
+            package_pattern = "*"
+
+        # Check if the package name matches the package pattern (if provided)
+        if fnmatch.fnmatch(package_name, package_pattern):
+            return True
+
+    return False

--- a/action_server/src/robocorp/action_server/_whitelist.py
+++ b/action_server/src/robocorp/action_server/_whitelist.py
@@ -1,7 +1,7 @@
 import fnmatch
 
 
-def normalize_name(name):
+def _normalize_name(name):
     """
     Normalizes action names to handle hyphens and underscores interchangeably.
     """
@@ -20,9 +20,9 @@ def accept_action(pattern: str, package_name: str, action_name: str) -> bool:
     Returns:
       True if the action matches the whitelist pattern, False otherwise.
     """
-    package_name = normalize_name(package_name)
-    action_name = normalize_name(action_name)
-    pattern = normalize_name(pattern)
+    package_name = _normalize_name(package_name)
+    action_name = _normalize_name(action_name)
+    pattern = _normalize_name(pattern)
 
     for single_pattern in pattern.split(","):
         # Check if the pattern includes a package name separated by '/'
@@ -53,8 +53,8 @@ def accept_action_package(pattern: str, package_name: str) -> bool:
     Returns:
       True if the action matches the whitelist pattern, False otherwise.
     """
-    package_name = normalize_name(package_name)
-    pattern = normalize_name(pattern)
+    package_name = _normalize_name(package_name)
+    pattern = _normalize_name(pattern)
 
     for single_pattern in pattern.split(","):
         # Check if the pattern includes a package name separated by '/'

--- a/action_server/tests/action_server_tests/test_action_unicode.py
+++ b/action_server/tests/action_server_tests/test_action_unicode.py
@@ -1,0 +1,36 @@
+import json
+import os
+
+from robocorp.action_server._selftest import ActionServerClient, ActionServerProcess
+
+
+def test_action_unicode(
+    action_server_process: ActionServerProcess,
+    client: ActionServerClient,
+    datadir,
+    str_regression,
+) -> None:
+    dir_contents = [x for x in os.listdir(datadir) if not x.startswith("test")]
+    assert len(dir_contents) == 1
+    action_server_process.start(
+        db_file="server.db",
+        cwd=str(os.path.join(str(datadir), dir_contents[0])),
+        actions_sync=True,
+        timeout=300,
+        lint=False,
+    )
+    str_regression.check(json.dumps(json.loads(client.get_openapi_json()), indent=4))
+
+    found = client.post_get_str(
+        "api/actions/acao-pkg/unicode-acao/run",
+        {"ação": "Foo"},
+    )
+    assert found == '"Foo"'
+
+
+def test_slugify():
+    from robocorp.action_server._slugify import slugify
+
+    assert slugify("ação", allow_unicode=True) == "ação"
+    assert slugify("ação", allow_unicode=False) == "acao"
+    assert slugify("ação /?*Σ 22", allow_unicode=False) == "acao-22"

--- a/action_server/tests/action_server_tests/test_action_unicode/ação_pkg/action_ação.py
+++ b/action_server/tests/action_server_tests/test_action_unicode/ação_pkg/action_ação.py
@@ -1,0 +1,7 @@
+from robocorp.actions import action
+
+
+@action
+def unicode_ação_Σ(ação: str) -> str:
+    assert isinstance(ação, str)
+    return ação

--- a/action_server/tests/action_server_tests/test_action_unicode/test_action_unicode.txt
+++ b/action_server/tests/action_server_tests/test_action_unicode/test_action_unicode.txt
@@ -1,0 +1,117 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Robocorp Actions Server",
+        "version": "0.1.0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:0"
+        }
+    ],
+    "paths": {
+        "/api/actions/acao-pkg/unicode-acao/run": {
+            "post": {
+                "summary": "Unicode A\u00e7\u00e3o \u03a3",
+                "operationId": "unicode_a\u00e7\u00e3o_\u03a3",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnicodeA__o_Input"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string",
+                                    "title": "Response Unicode A\u00e7\u00e3o \u03a3"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "HTTPValidationError": {
+                "properties": {
+                    "errors": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationError"
+                        },
+                        "type": "array",
+                        "title": "Errors"
+                    }
+                },
+                "type": "object",
+                "title": "HTTPValidationError"
+            },
+            "UnicodeA__o_Input": {
+                "properties": {
+                    "a\u00e7\u00e3o": {
+                        "type": "string",
+                        "title": "A\u00e7\u00e3o",
+                        "description": ""
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "a\u00e7\u00e3o"
+                ],
+                "title": "UnicodeA\u00e7\u00e3o\u03a3Input"
+            },
+            "ValidationError": {
+                "properties": {
+                    "loc": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Location"
+                    },
+                    "msg": {
+                        "type": "string",
+                        "title": "Message"
+                    },
+                    "type": {
+                        "type": "string",
+                        "title": "Error Type"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "loc",
+                    "msg",
+                    "type"
+                ],
+                "title": "ValidationError"
+            }
+        }
+    }
+}

--- a/action_server/tests/action_server_tests/test_server_whitelist.py
+++ b/action_server/tests/action_server_tests/test_server_whitelist.py
@@ -1,0 +1,123 @@
+import json
+from pathlib import Path
+
+from robocorp.action_server._selftest import ActionServerClient, ActionServerProcess
+from robocorp.action_server._whitelist import accept_action
+
+
+def test_whitelist_exact_match():
+    """Tests if an exact match is accepted."""
+    assert accept_action("action1", "package", "action1")
+    assert not accept_action("action1", "any-package-name", "action2")
+
+
+def test_whitelist_package_match():
+    """Tests if an action in a specific package is accepted."""
+    assert accept_action("package1/action1", "package1", "action1")
+    assert not accept_action("package1/action1", "package2", "action1")
+
+
+def test_whitelist_wildcard_match():
+    """Tests if an action is accepted using wildcards."""
+    assert accept_action("action*", "any-name", "action1")
+    assert accept_action("action*", "any-name", "action_name")
+    assert not accept_action("other_action*", "any-name", "action1")
+
+
+def test_whitelist_multiple_patterns():
+    """Tests if multiple patterns separated by comma are accepted."""
+    assert accept_action("action1,action2", "any-name", "action1")
+    assert accept_action("action1,action2", "any-name", "action2")
+    assert not accept_action("action1,action2", "any-name", "action3")
+
+
+def test_whitelist_hyphen_underscore_match():
+    """Tests if hyphens and underscores are treated interchangeably."""
+    assert accept_action("action_1", "any-name", "action-1")
+    assert accept_action("action-2", "any-name", "action_2")
+
+
+def test_whitelist_on_import(
+    str_regression,
+    tmpdir,
+    action_server_datadir: Path,
+    client: ActionServerClient,
+) -> None:
+    from action_server_tests.fixtures import robocorp_action_server_run
+
+    from robocorp.action_server._database import Database
+    from robocorp.action_server._models import Action, load_db
+
+    action_server_datadir.mkdir(parents=True, exist_ok=True)
+    db_path = action_server_datadir / "server.db"
+    assert not db_path.exists()
+
+    calculator = Path(tmpdir) / "v1" / "calculator" / "action_calculator.py"
+    calculator.parent.mkdir(parents=True, exist_ok=True)
+    calculator.write_text(
+        """
+from robocorp.actions import action
+
+@action
+def calculator_sum(v1: float, v2: float) -> float:
+    return v1 + v2
+    
+@action
+def calculator_subtract(v1: float, v2: float) -> float:
+    return v1 - v2
+"""
+    )
+
+    robocorp_action_server_run(
+        [
+            "import",
+            f"--dir={calculator.parent}",
+            "--db-file=server.db",
+            "-v",
+            "--skip-lint",
+            "--datadir",
+            action_server_datadir,
+            "--whitelist",
+            "calculator_sum",
+        ],
+        returncode=0,
+    )
+
+    db: Database
+    with load_db(db_path) as db:
+        with db.connect():
+            actions = db.all(Action)
+            assert len(actions) == 1
+
+
+def test_whitelist_on_start(
+    action_server_process: ActionServerProcess,
+    str_regression,
+    tmpdir,
+    client: ActionServerClient,
+) -> None:
+    calculator = Path(tmpdir) / "v1" / "calculator" / "action_calculator.py"
+    calculator.parent.mkdir(parents=True, exist_ok=True)
+    calculator.write_text(
+        """
+from robocorp.actions import action
+
+@action
+def calculator_sum(v1: float, v2: float) -> float:
+    return v1 + v2
+    
+@action
+def calculator_subtract(v1: float, v2: float) -> float:
+    return v1 - v2
+"""
+    )
+
+    action_server_process.start(
+        db_file="server.db",
+        cwd=calculator.parent,
+        timeout=50,
+        actions_sync=True,
+        additional_args=["--whitelist", "calculator_sum"],
+    )
+
+    str_regression.check(json.dumps(json.loads(client.get_openapi_json()), indent=4))

--- a/action_server/tests/action_server_tests/test_server_whitelist/test_whitelist_on_start.txt
+++ b/action_server/tests/action_server_tests/test_server_whitelist/test_whitelist_on_start.txt
@@ -1,0 +1,123 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Robocorp Actions Server",
+        "version": "0.1.0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:0"
+        }
+    ],
+    "paths": {
+        "/api/actions/calculator/calculator-sum/run": {
+            "post": {
+                "summary": "Calculator Sum",
+                "operationId": "calculator_sum",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CalculatorSumInput"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "number",
+                                    "title": "Response Calculator Sum"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "CalculatorSumInput": {
+                "properties": {
+                    "v1": {
+                        "type": "number",
+                        "title": "V1",
+                        "description": ""
+                    },
+                    "v2": {
+                        "type": "number",
+                        "title": "V2",
+                        "description": ""
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "v1",
+                    "v2"
+                ],
+                "title": "CalculatorSumInput"
+            },
+            "HTTPValidationError": {
+                "properties": {
+                    "errors": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationError"
+                        },
+                        "type": "array",
+                        "title": "Errors"
+                    }
+                },
+                "type": "object",
+                "title": "HTTPValidationError"
+            },
+            "ValidationError": {
+                "properties": {
+                    "loc": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Location"
+                    },
+                    "msg": {
+                        "type": "string",
+                        "title": "Message"
+                    },
+                    "type": {
+                        "type": "string",
+                        "title": "Error Type"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "loc",
+                    "msg",
+                    "type"
+                ],
+                "title": "ValidationError"
+            }
+        }
+    }
+}

--- a/log/docs/CHANGELOG.md
+++ b/log/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed issue writing unicode to the output when the contents cannot be encoded with the stdout/stderr encoding.
+
 ## 2.9.0 - 2024-01-19
 
 - Added auxiliary function `iter_decoded_log_format_from_log_html_contents` to `robocorp.log` to public API.

--- a/log/docs/api/robocorp.log.md
+++ b/log/docs/api/robocorp.log.md
@@ -250,7 +250,7 @@ ______________________________________________________________________
 
 ## function `suppress_methods`
 
-**Source:** [`__init__.py:417`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L417)
+**Source:** [`__init__.py:419`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L419)
 
 ```python
 suppress_methods()
@@ -277,7 +277,7 @@ ______________________________________________________________________
 
 ## function `suppress_variables`
 
-**Source:** [`__init__.py:438`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L438)
+**Source:** [`__init__.py:440`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L440)
 
 ```python
 suppress_variables()
@@ -304,7 +304,7 @@ ______________________________________________________________________
 
 ## function `suppress`
 
-**Source:** [`__init__.py:487`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L487)
+**Source:** [`__init__.py:489`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L489)
 
 ```python
 suppress(*args, **kwargs)
@@ -355,7 +355,7 @@ ______________________________________________________________________
 
 ## function `is_sensitive_variable_name`
 
-**Source:** [`__init__.py:533`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L533)
+**Source:** [`__init__.py:535`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L535)
 
 ```python
 is_sensitive_variable_name(variable_name: str) → bool
@@ -374,7 +374,7 @@ ______________________________________________________________________
 
 ## function `add_sensitive_variable_name`
 
-**Source:** [`__init__.py:547`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L547)
+**Source:** [`__init__.py:549`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L549)
 
 ```python
 add_sensitive_variable_name(variable_name: str) → None
@@ -394,7 +394,7 @@ ______________________________________________________________________
 
 ## function `add_sensitive_variable_name_pattern`
 
-**Source:** [`__init__.py:563`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L563)
+**Source:** [`__init__.py:565`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L565)
 
 ```python
 add_sensitive_variable_name_pattern(variable_name_pattern: str) → None
@@ -412,7 +412,7 @@ ______________________________________________________________________
 
 ## function `hide_from_output`
 
-**Source:** [`__init__.py:576`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L576)
+**Source:** [`__init__.py:578`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L578)
 
 ```python
 hide_from_output(string_to_hide: str) → None
@@ -434,7 +434,7 @@ ______________________________________________________________________
 
 ## function `hide_strings_config`
 
-**Source:** [`__init__.py:619`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L619)
+**Source:** [`__init__.py:621`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L621)
 
 ```python
 hide_strings_config() → IRedactConfiguration
@@ -468,7 +468,7 @@ ______________________________________________________________________
 
 ## function `start_run`
 
-**Source:** [`__init__.py:651`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L651)
+**Source:** [`__init__.py:653`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L653)
 
 ```python
 start_run(name: str) → None
@@ -486,7 +486,7 @@ ______________________________________________________________________
 
 ## function `end_run`
 
-**Source:** [`__init__.py:665`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L665)
+**Source:** [`__init__.py:667`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L667)
 
 ```python
 end_run(name: str, status: str) → None
@@ -505,7 +505,7 @@ ______________________________________________________________________
 
 ## function `start_task`
 
-**Source:** [`__init__.py:680`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L680)
+**Source:** [`__init__.py:682`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L682)
 
 ```python
 start_task(
@@ -533,7 +533,7 @@ ______________________________________________________________________
 
 ## function `end_task`
 
-**Source:** [`__init__.py:700`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L700)
+**Source:** [`__init__.py:702`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L702)
 
 ```python
 end_task(name: str, libname: str, status: str, message: str) → None
@@ -554,7 +554,7 @@ ______________________________________________________________________
 
 ## function `iter_decoded_log_format_from_stream`
 
-**Source:** [`__init__.py:720`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L720)
+**Source:** [`__init__.py:722`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L722)
 
 ```python
 iter_decoded_log_format_from_stream(stream: IReadLines) → Iterator[dict]
@@ -589,7 +589,7 @@ ______________________________________________________________________
 
 ## function `iter_decoded_log_format_from_log_html`
 
-**Source:** [`__init__.py:751`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L751)
+**Source:** [`__init__.py:753`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L753)
 
 ```python
 iter_decoded_log_format_from_log_html(log_html: Path) → Iterator[dict]
@@ -620,7 +620,7 @@ ______________________________________________________________________
 
 ## function `iter_decoded_log_format_from_log_html_contents`
 
-**Source:** [`__init__.py:777`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L777)
+**Source:** [`__init__.py:779`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L779)
 
 ```python
 iter_decoded_log_format_from_log_html_contents(
@@ -654,7 +654,7 @@ ______________________________________________________________________
 
 ## function `verify_log_messages_from_messages_iterator`
 
-**Source:** [`__init__.py:843`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L843)
+**Source:** [`__init__.py:845`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L845)
 
 ```python
 verify_log_messages_from_messages_iterator(
@@ -705,7 +705,7 @@ ______________________________________________________________________
 
 ## function `verify_log_messages_from_decoded_str`
 
-**Source:** [`__init__.py:924`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L924)
+**Source:** [`__init__.py:926`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L926)
 
 ```python
 verify_log_messages_from_decoded_str(
@@ -729,7 +729,7 @@ ______________________________________________________________________
 
 ## function `verify_log_messages_from_log_html`
 
-**Source:** [`__init__.py:982`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L982)
+**Source:** [`__init__.py:984`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L984)
 
 ```python
 verify_log_messages_from_log_html(
@@ -753,7 +753,7 @@ ______________________________________________________________________
 
 ## function `verify_log_messages_from_stream`
 
-**Source:** [`__init__.py:1002`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1002)
+**Source:** [`__init__.py:1004`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1004)
 
 ```python
 verify_log_messages_from_stream(
@@ -777,7 +777,7 @@ ______________________________________________________________________
 
 ## function `setup_log`
 
-**Source:** [`__init__.py:1058`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1058)
+**Source:** [`__init__.py:1060`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1060)
 
 ```python
 setup_log(
@@ -848,7 +848,7 @@ ______________________________________________________________________
 
 ## function `setup_auto_logging`
 
-**Source:** [`__init__.py:1192`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1192)
+**Source:** [`__init__.py:1194`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1194)
 
 ```python
 setup_auto_logging(
@@ -873,7 +873,7 @@ ______________________________________________________________________
 
 ## function `add_log_output`
 
-**Source:** [`__init__.py:1225`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1225)
+**Source:** [`__init__.py:1227`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1227)
 
 ```python
 add_log_output(
@@ -908,7 +908,7 @@ ______________________________________________________________________
 
 ## function `close_log_outputs`
 
-**Source:** [`__init__.py:1289`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1289)
+**Source:** [`__init__.py:1291`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1291)
 
 ```python
 close_log_outputs()
@@ -922,7 +922,7 @@ ______________________________________________________________________
 
 ## function `add_in_memory_log_output`
 
-**Source:** [`__init__.py:1306`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1306)
+**Source:** [`__init__.py:1308`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1308)
 
 ```python
 add_in_memory_log_output(write: Callable[[str], Any])
@@ -947,7 +947,7 @@ ______________________________________________________________________
 
 ## class `IRedactConfiguration`
 
-**Source:** [`__init__.py:596`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L596)
+**Source:** [`__init__.py:598`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L598)
 
 #### property `dont_hide_strings`
 
@@ -963,7 +963,7 @@ ______________________________________________________________________
 
 ## enum `FilterLogLevel`
 
-**Source:** [`__init__.py:1027`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1027)
+**Source:** [`__init__.py:1029`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1029)
 
 An enumeration.
 
@@ -979,6 +979,6 @@ ______________________________________________________________________
 
 ## class `IContextManager`
 
-**Source:** [`__init__.py:1038`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1038)
+**Source:** [`__init__.py:1040`](https://github.com/robocorp/robocorp/tree/master/log/src/robocorp/log/__init__.py#L1040)
 
 Typing for a "generic" context manager.

--- a/log/src/robocorp/log/__init__.py
+++ b/log/src/robocorp/log/__init__.py
@@ -339,6 +339,8 @@ def console_message(
         flush: Whether we should flush after sending the message (if None
                it's flushed if the end char ends with '\n').
     """
+    from ._safe_write_to_stream import safe_write_to_stream
+
     try:
         writing = _ConsoleMessagesLock.tlocal._writing
     except Exception:
@@ -377,7 +379,7 @@ def console_message(
                 ctx = nullcontext()
 
             with ctx:
-                stream.write(message)
+                safe_write_to_stream(stream, message)
 
             if flush is None:
                 flush = message.endswith("\n")

--- a/log/src/robocorp/log/_robo_output_impl.py
+++ b/log/src/robocorp/log/_robo_output_impl.py
@@ -373,7 +373,9 @@ class _RoboOutputImpl:
         self._next_int: "partial[int]" = partial(next, itertools.count(0))
 
     def show_error_message(self, msg):
-        sys.stderr.write(msg)
+        from robocorp.log._safe_write_to_stream import safe_write_to_stream
+
+        safe_write_to_stream(sys.stderr, msg)
         if self.on_show_error_message:
             self.on_show_error_message(msg)
 

--- a/log/src/robocorp/log/_safe_write_to_stream.py
+++ b/log/src/robocorp/log/_safe_write_to_stream.py
@@ -1,0 +1,40 @@
+import typing
+
+
+def safe_write_to_stream(stream: typing.IO, contents: str) -> None:
+    """
+    Writes the given contents to the stream making sure that no `UnicodeEncodeError`
+    happens.
+    """
+    try:
+        stream.write(contents)
+        return
+    except UnicodeEncodeError:
+        pass  # keep on going...
+
+    # UnicodeEncodeError error happened. Most likely the contents do not match
+    # the encoding needed by the stream.
+    buffer = getattr(stream, "buffer", None)
+    encoding = getattr(stream, "encoding", None)
+    if not encoding:
+        encoding = "utf-8"
+
+    if buffer is not None:
+        # If possible write to buffer which uses binary interface
+        # (and shouldn't fail regardless of the bytes).
+        bytes_to_write = contents.encode(encoding, errors="replace")
+        buffer.write(bytes_to_write)
+        return
+
+    # No buffer available, let's try to make sure that we have the
+    # proper contents for the given encoding.
+    replaced = contents.encode(encoding, errors="replace").decode(encoding)
+    try:
+        stream.write(replaced)
+        return
+    except UnicodeEncodeError:
+        pass  # keep on going
+
+    # Last attempt: write as ascii.
+    replaced = contents.encode("ascii", errors="replace").decode("ascii")
+    stream.write(replaced)

--- a/log/src/robocorp/log/redirect.py
+++ b/log/src/robocorp/log/redirect.py
@@ -191,6 +191,8 @@ def setup_stdout_logging(
                 EXIT = object()
 
                 def in_thread():
+                    from robocorp.log._safe_write_to_stream import safe_write_to_stream
+
                     while True:
                         msg = q.get(block=True)
                         if msg is EXIT:
@@ -212,11 +214,15 @@ def setup_stdout_logging(
                                             if not buf:
                                                 break
                                             i += 1024
-                                            original_stdout.write(f"{buf}")
+                                            safe_write_to_stream(
+                                                original_stdout, f"{buf}"
+                                            )
                                             original_stdout.flush()
                                         original_stdout.write("\n")
                                     else:
-                                        original_stdout.write(f"{decoded}\n")
+                                        safe_write_to_stream(
+                                            original_stdout, f"{decoded}\n"
+                                        )
                                     # Flush (so, clients don't need to execute as unbuffered).
                                     original_stdout.flush()
                         except Exception:

--- a/log/tests/robocorp_log_tests/test_safe_write_to_stream.py
+++ b/log/tests/robocorp_log_tests/test_safe_write_to_stream.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import sys
+
+from robocorp.log._safe_write_to_stream import safe_write_to_stream
+
+
+def test_write_to_stream():
+    """
+    We run in a subprocess that only accepts ascii in the output
+    to check that our safe_write_to_stream works properly.
+    """
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "ascii"
+    result = subprocess.run(
+        [sys.executable, __file__], encoding="ascii", env=env, stdout=subprocess.PIPE
+    )
+    assert result.stdout == "a??o\n"
+
+
+def check_safe_write_to_stream():
+    stdout = sys.stdout
+    encoding = stdout.encoding
+    assert encoding == "ascii", f"Found encoding: {encoding}"
+    try:
+        stdout.write("ação\n")
+    except UnicodeEncodeError:
+        pass
+    else:
+        raise AssertionError(
+            "Expected an error when writing to stdout with unicode chars."
+        )
+
+    safe_write_to_stream(stdout, "ação\n")
+
+
+if __name__ == "__main__":
+    check_safe_write_to_stream()

--- a/tasks/tests/tasks_tests/test_fixtures.py
+++ b/tasks/tests/tasks_tests/test_fixtures.py
@@ -12,12 +12,18 @@ from robocorp.tasks._hooks import (
 )
 
 
-@pytest.fixture(autouse=True)
-def clear_callbacks():
+def _clear_callbacks():
     before_task_run._callbacks = ()
     before_all_tasks_run._callbacks = ()
     after_task_run._callbacks = ()
     after_all_tasks_run._callbacks = ()
+
+
+@pytest.fixture(autouse=True)
+def clear_callbacks():
+    _clear_callbacks()
+    yield
+    _clear_callbacks()
 
 
 def test_setup_default():

--- a/tasks/tests/tasks_tests/test_lifecycle.py
+++ b/tasks/tests/tasks_tests/test_lifecycle.py
@@ -1,7 +1,28 @@
 import itertools
 
+import pytest
+
 from robocorp.tasks import session_cache
-from robocorp.tasks._hooks import after_all_tasks_run
+from robocorp.tasks._hooks import (
+    after_all_tasks_run,
+    after_task_run,
+    before_all_tasks_run,
+    before_task_run,
+)
+
+
+def _clear_callbacks():
+    before_task_run._callbacks = ()
+    before_all_tasks_run._callbacks = ()
+    after_task_run._callbacks = ()
+    after_all_tasks_run._callbacks = ()
+
+
+@pytest.fixture(autouse=True)
+def clear_callbacks():
+    _clear_callbacks()
+    yield
+    _clear_callbacks()
 
 
 def test_session_cache_yield():

--- a/tasks/tests/tasks_tests/test_task_schema.py
+++ b/tasks/tests/tasks_tests/test_task_schema.py
@@ -91,7 +91,7 @@ def test_task_schema_default_value_type():
     }
 
 
-def methodd(a: int = 1) -> int:
+def unicode_ação_Σ(ação: int = 1) -> int:
     """
     This is a method. In this method
     the description spans multiple lines
@@ -99,7 +99,7 @@ def methodd(a: int = 1) -> int:
     in the spec.
 
     Args:
-        a: This is argument a.
+        ação: This is an argument
 
     Returns:
         The number 1.
@@ -107,8 +107,20 @@ def methodd(a: int = 1) -> int:
     return 1
 
 
-def test_task_schema_multiple_lines_in_description():
+def test_task_unicode():
     from robocorp.tasks._task import Task
 
-    task = Task(__name__, __file__, methodd)
-    print(task.__doc__)
+    task = Task(__name__, __file__, unicode_ação_Σ)
+    input_schema = task.input_schema
+    assert input_schema == {
+        "additionalProperties": False,
+        "properties": {
+            "ação": {
+                "type": "integer",
+                "description": "This is an argument",
+                "title": "Ação",
+                "default": 1,
+            }
+        },
+        "type": "object",
+    }

--- a/tasks/tests/tasks_tests/test_tasks_arguments.py
+++ b/tasks/tests/tasks_tests/test_tasks_arguments.py
@@ -35,6 +35,10 @@ def test_tasks_arguments_json_input(datadir, tmpdir) -> None:
     )
 
 
+def test_tasks_unicode(datadir) -> None:
+    check(datadir, ["-t=unicode_ação_Σ", "--", "--ação=1"], returncode=0)
+
+
 def test_tasks_arguments(datadir) -> None:
     check(datadir, ["-t=accept_str", "--", "--s=1"], returncode=0)
 

--- a/tasks/tests/tasks_tests/test_tasks_arguments/tasks.py
+++ b/tasks/tests/tasks_tests/test_tasks_arguments/tasks.py
@@ -31,3 +31,8 @@ def bool_false(b: bool) -> None:
 @task
 def accept_str(s) -> None:
     assert isinstance(s, str)
+
+
+@task
+def unicode_ação_Σ(ação: str) -> None:
+    assert isinstance(ação, str)


### PR DESCRIPTION
- The action package name is now gotten from the `package.yaml` and not from the directory name
  (it's still gotten from the directory name when `conda.yaml` is used for backward compatibility).

- The action package name and action name are slugified to be ascii only and replace
  unwanted chars for `-` in the urls.

- A `--whitelist` argument is accepted in the command line for `start` and `import` and
  it allows whitelisting action package names as well as action names. 