### PR TITLE
Format action output in local action server UI

### DIFF
--- a/action_server/frontend/src/views/actions/components/ActionRun.tsx
+++ b/action_server/frontend/src/views/actions/components/ActionRun.tsx
@@ -1,5 +1,15 @@
 import { FC, FormEvent, ReactNode, useCallback, useEffect, useState } from 'react';
-import { Box, Button, Checkbox, Form, Input, Select, Typography } from '@robocorp/components';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Divider,
+  Form,
+  Input,
+  Select,
+  Typography,
+} from '@robocorp/components';
+import { IconBolt } from '@robocorp/icons/iconic';
 
 import { Action, ActionPackage } from '~/lib/types';
 import { toKebabCase } from '~/lib/helpers';
@@ -155,12 +165,25 @@ export const ActionRun: FC<Props> = ({ action, actionPackage }) => {
           }
         })}
       </Form.Fieldset>
-      <Button.Group align="right">
-        <Button loading={isPending} type="submit" variant="primary">
-          Run
+      <Button.Group align="right" marginBottom={16}>
+        <Button
+          loading={isPending}
+          type="submit"
+          variant="primary"
+          icon={IconBolt}
+          style={{ width: '160px' }}
+        >
+          {isPending ? 'Executing...' : 'Execute Action'}
         </Button>
       </Button.Group>
-      {isSuccess && <ActionRunResult result={data.response} runId={data.runId} />}
+      <Divider />
+      {isSuccess && (
+        <ActionRunResult
+          result={data.response}
+          runId={data.runId}
+          outputSchemaType={JSON.parse(action.output_schema) as { type: string }}
+        />
+      )}
     </Form>
   );
 };

--- a/action_server/frontend/src/views/actions/components/ActionRunResult.tsx
+++ b/action_server/frontend/src/views/actions/components/ActionRunResult.tsx
@@ -6,15 +6,24 @@ import { ActionRunConsole, Code } from '~/components';
 type Props = {
   result: string;
   runId: string;
+  outputSchemaType?: { type: string };
 };
 
-export const ActionRunResult: FC<Props> = ({ result, runId }) => {
+const getFormattedString = (value: string): string => {
+  const fmt = value.replaceAll('\\n', '\n').trim();
+  if (fmt.charAt(0) === '"' && fmt.charAt(fmt.length - 1) === '"') {
+    return fmt.substring(1, fmt.length - 1);
+  }
+  return fmt;
+};
+
+export const ActionRunResult: FC<Props> = ({ result, runId, outputSchemaType }) => {
   return (
     <>
       <Header size="small">
-        <Header.Title title="Result" />
+        <Header.Title title={outputSchemaType ? `Result (${outputSchemaType.type})` : 'Result'} />
       </Header>
-      <Code lineNumbers={false} value={result} />
+      <Code lineNumbers={false} lineWrapping value={getFormattedString(result)} />
 
       <Header size="small">
         <Header.Title title="Console output" />


### PR DESCRIPTION
Formatting result for the code mirror editor to show returns correctly. Some small stylisation to the Run drawer

- Changed 'Run' to 'Execute Action' & 'Executing' while in progress
- Added icon to button
- Formatted result string
- Added result type alongside the 'Result' header

![image](https://github.com/robocorp/robocorp/assets/10797145/c0fc1878-2128-4160-bef2-420cf8259905)

![image](https://github.com/robocorp/robocorp/assets/10797145/63fc3499-d3da-4643-9ce3-1e9821f14fb8)
![image](https://github.com/robocorp/robocorp/assets/10797145/572d2d1c-9312-40c8-88f3-c6bc13bffaa7)
![image](https://github.com/robocorp/robocorp/assets/10797145/45b8c1ca-45b4-4f96-8b00-016029dcef73)
