### PR TITLE
Expose the action package name in package metadata

### DIFF
--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Return package name in package metadata
+
 ## 0.3.2 - 2024-04-12
 
 - Fixed issue where auto-update message could break commands which wrote to stdout (such as version or package metadata).

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -140,7 +140,6 @@ def start_server(
         func, openapi_extra = _actions_run.generate_func_from_action(action)
         if action.is_consequential is not None:
             openapi_extra["x-openai-isConsequential"] = action.is_consequential
-        openapi_extra["package-name"] = action_package.name
 
         app.add_api_route(
             build_url_api_run(action_package.name, action.name),

--- a/action_server/src/robocorp/action_server/_server.py
+++ b/action_server/src/robocorp/action_server/_server.py
@@ -140,6 +140,7 @@ def start_server(
         func, openapi_extra = _actions_run.generate_func_from_action(action)
         if action.is_consequential is not None:
             openapi_extra["x-openai-isConsequential"] = action.is_consequential
+        openapi_extra["package-name"] = action_package.name
 
         app.add_api_route(
             build_url_api_run(action_package.name, action.name),

--- a/action_server/src/robocorp/action_server/package/_package_metadata.py
+++ b/action_server/src/robocorp/action_server/package/_package_metadata.py
@@ -52,6 +52,7 @@ def collect_package_metadata(package_dir: Path, datadir: str) -> str | int:
                     }
 
         metadata["metadata"] = {"secrets": secrets}
+        metadata["action_package_name"] = action_package.name
 
     def collect_metadata_and_cancel_startup(app: FastAPI) -> bool:
         nonlocal metadata

--- a/action_server/src/robocorp/action_server/package/_package_metadata.py
+++ b/action_server/src/robocorp/action_server/package/_package_metadata.py
@@ -52,7 +52,7 @@ def collect_package_metadata(package_dir: Path, datadir: str) -> str | int:
                     }
 
         metadata["metadata"] = {"secrets": secrets}
-        metadata["action_package_name"] = action_package.name
+        metadata["metadata"]["name"] = action_package.name
 
     def collect_metadata_and_cancel_startup(app: FastAPI) -> bool:
         nonlocal metadata

--- a/action_server/tests/action_server_tests/test_package/test_package_metadata.yml
+++ b/action_server/tests/action_server_tests/test_package/test_package_metadata.yml
@@ -1,4 +1,5 @@
 metadata:
+  name: pack1 name
   secrets: {}
 openapi.json:
   components:

--- a/action_server/tests/action_server_tests/test_package/test_package_metadata_secrets.yml
+++ b/action_server/tests/action_server_tests/test_package/test_package_metadata_secrets.yml
@@ -1,4 +1,5 @@
 metadata:
+  name: pack_secrets
   secrets:
     /api/actions/pack-secrets/hello/run:
       action: hello


### PR DESCRIPTION
Fixes #342 

We currently have no reliable way to tell the action package name from the `metadata`.
I propose always returning the action package name under `metadata["metadata"]["name"]`

- Adds `action_package` field to each action path


e.g. for `package.yaml`
```yaml

# Required: A short name for the action package
name: dev-action

...
```
you'd get
```json
{
  "metadata": {
    "secrets": {},
    "name": "dev-action"
  },
  "openapi.json": {
  // ...
  }
}
```