### PR TITLE
Expose the action package description in package metadata

### DIFF
--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Return package name in package metadata
+- Return package description in package metadata
 
 ## 0.3.2 - 2024-04-12
 

--- a/action_server/src/robocorp/action_server/package/_package_metadata.py
+++ b/action_server/src/robocorp/action_server/package/_package_metadata.py
@@ -51,8 +51,20 @@ def collect_package_metadata(package_dir: Path, datadir: str) -> str | int:
                         "secrets": found_secrets,
                     }
 
-        metadata["metadata"] = {"secrets": secrets}
-        metadata["metadata"]["name"] = action_package.name
+        package_description = ""
+        package_yaml_path = Path(package_dir) / "package.yaml"
+        if package_yaml_path.exists():
+            import yaml
+
+            with package_yaml_path.open() as f:
+                package_yaml = yaml.safe_load(f)
+                package_description = package_yaml.get("description", "")
+
+        metadata["metadata"] = {
+            "name": action_package.name,
+            "description": package_description,
+            "secrets": secrets,
+        }
 
     def collect_metadata_and_cancel_startup(app: FastAPI) -> bool:
         nonlocal metadata

--- a/action_server/tests/action_server_tests/test_package/pack1/package.yaml
+++ b/action_server/tests/action_server_tests/test_package/pack1/package.yaml
@@ -1,4 +1,5 @@
 name: pack1 name
+description: pack1 description
 version: 0.2a1
 
 dependencies:

--- a/action_server/tests/action_server_tests/test_package/test_package_metadata.yml
+++ b/action_server/tests/action_server_tests/test_package/test_package_metadata.yml
@@ -1,4 +1,5 @@
 metadata:
+  description: pack1 description
   name: pack1 name
   secrets: {}
 openapi.json:

--- a/action_server/tests/action_server_tests/test_package/test_package_metadata_secrets.yml
+++ b/action_server/tests/action_server_tests/test_package/test_package_metadata_secrets.yml
@@ -1,4 +1,5 @@
 metadata:
+  description: ''
   name: pack_secrets
   secrets:
     /api/actions/pack-secrets/hello/run:


### PR DESCRIPTION
Related to #342 

Continuation of https://github.com/robocorp/robocorp/pull/366.

We currently have no reliable way to tell the action package description from the `metadata`.

- Adds `metadata["metadata"]["description"]` field


e.g. for `package.yaml`
```yaml

description: Kristaps dev actions

...
```
you'd get
```json
{
  "metadata": {
    "secrets": {},
    "description": "Kristaps dev actions"
  },
  "openapi.json": {
  // ...
  }
}
```