### PR TITLE
docs: Fix documentation for encryption algo

### DIFF
--- a/action_server/docs/guides/07-secrets.md
+++ b/action_server/docs/guides/07-secrets.md
@@ -69,7 +69,7 @@ In that case the `X-Action-Context` header contents should be something as:
 ```
 base64({
     "cipher": base64(encrypted_data(JSON.stringify(content))),
-    "algorithm": "aes256-cdc",
+    "algorithm": "aes256-gcm",
     "iv": base64(nonce),
 })
 ```
@@ -89,7 +89,7 @@ encrypted_data = encrypt(key, nonce, data)
 
 action_server_context = {
     "cipher": base64.b64encode(encrypted_data).decode("ascii"),
-    "algorithm": "aes256-cdc",
+    "algorithm": "aes256-gcm",
     "iv": base64.b64encode(nonce).decode("ascii"),
 }
 


### PR DESCRIPTION
Docs mention `aes256-cdc`, which is a typo of `aes256-cbc`. This PR corrects it but changes it to `aes256-gcm` instead, which is a more-likely value for this use case.