### PR TITLE
Fix windows package test locators

### DIFF
--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_chrome.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_chrome.py
@@ -31,15 +31,11 @@ def _check_multiple_interactions():
         app.find(
             'control:"ButtonControl" and regex:Don.*sign.*in', search_depth=12
         ).click()
-        app.find(
-            'control:"ButtonControl" and name:Skip', search_depth=12
-        ).click()
+        app.find('control:"ButtonControl" and name:Skip', search_depth=12).click()
     except windows.ElementNotFound:
         pass  # Ignore if not there.
 
-    w = windows.find_window(
-        "regex:New Tab.*Google Chrome", wait_time=0.5, timeout=5
-    )
+    w = windows.find_window("regex:New Tab.*Google Chrome", wait_time=0.5, timeout=5)
     w.send_keys("{Alt}d", wait_time=0.2, send_enter=False)
     w.send_keys(url, wait_time=3, send_enter=True)
 
@@ -56,9 +52,7 @@ def _check_multiple_interactions():
 
     # Test drag and drop
     div_header_item = w.find("id:mydiv > id:mydivheader", search_depth=12)
-    move_item = w.find(
-        "id:mydiv > control:TextControl name:Move", search_depth=12
-    )
+    move_item = w.find("id:mydiv > control:TextControl name:Move", search_depth=12)
 
     original_top = div_header_item.top
     desktop.drag_and_drop(div_header_item, move_item)

--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_chrome.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_chrome.py
@@ -32,7 +32,7 @@ def _check_multiple_interactions():
     except windows.ElementNotFound:
         pass  # Ignore if not there.
 
-    w = windows.find_window("regex:.*New Tab - Google Chrome", wait_time=0.5, timeout=5)
+    w = windows.find_window("regex:.*Google Chrome", wait_time=0.5, timeout=5)
     w.send_keys("{Alt}d", wait_time=0.2, send_enter=False)
     w.send_keys(url, wait_time=3, send_enter=True)
 

--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_chrome.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_chrome.py
@@ -28,7 +28,12 @@ def _check_multiple_interactions():
     # We have to decline
     try:
         app = windows.find_window("regex:.*Google Chrome", timeout=5)
-        app.find('control:"ButtonControl" and name:"Close"').click()
+        app.find(
+            'control:"ButtonControl" and regex:Don.*sign.*in', search_depth=12
+        ).click()
+        app.find(
+            'control:"ButtonControl" and name:Skip', search_depth=12
+        ).click()
     except windows.ElementNotFound:
         pass  # Ignore if not there.
 

--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_chrome.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_chrome.py
@@ -27,12 +27,14 @@ def _check_multiple_interactions():
     # In GitHub Actions on a fresh install Chrome asks to sign in.
     # We have to decline
     try:
-        app = windows.find_window("regex:.*Sign in to Chrome", timeout=5)
+        app = windows.find_window("regex:.*Google Chrome", timeout=5)
         app.find('control:"ButtonControl" and name:"Close"').click()
     except windows.ElementNotFound:
         pass  # Ignore if not there.
 
-    w = windows.find_window("regex:.*Google Chrome", wait_time=0.5, timeout=5)
+    w = windows.find_window(
+        "regex:New Tab.*Google Chrome", wait_time=0.5, timeout=5
+    )
     w.send_keys("{Alt}d", wait_time=0.2, send_enter=False)
     w.send_keys(url, wait_time=3, send_enter=True)
 
@@ -49,7 +51,9 @@ def _check_multiple_interactions():
 
     # Test drag and drop
     div_header_item = w.find("id:mydiv > id:mydivheader", search_depth=12)
-    move_item = w.find("id:mydiv > control:TextControl name:Move", search_depth=12)
+    move_item = w.find(
+        "id:mydiv > control:TextControl name:Move", search_depth=12
+    )
 
     original_top = div_header_item.top
     desktop.drag_and_drop(div_header_item, move_item)

--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_chrome.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_chrome.py
@@ -37,19 +37,19 @@ def _check_multiple_interactions():
     w.send_keys(url, wait_time=3, send_enter=True)
 
     # Test select
-    combo = w.find("control:ComboBoxControl id:cars", search_depth=10)
+    combo = w.find("control:ComboBoxControl id:cars", search_depth=12)
     combo.select("Audi")
     assert combo.get_value() == "Audi"
 
     # Test get_value/set_value
-    text_control = w.find('control:EditControl name:"First name:"', search_depth=9)
+    text_control = w.find("id:fname", search_depth=12)
     assert text_control.get_value() == ""
     text_control.set_value("22")
     assert text_control.get_value() == "22"
 
     # Test drag and drop
-    div_header_item = w.find("id:mydiv > id:mydivheader")
-    move_item = w.find("id:mydiv > control:TextControl name:Move")
+    div_header_item = w.find("id:mydiv > id:mydivheader", search_depth=12)
+    move_item = w.find("id:mydiv > control:TextControl name:Move", search_depth=12)
 
     original_top = div_header_item.top
     desktop.drag_and_drop(div_header_item, move_item)

--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
@@ -1,4 +1,5 @@
 def _start_explorer_at_folder(folder: str):
+    import time
     from robocorp import windows
 
     desktop = windows.desktop()
@@ -6,10 +7,15 @@ def _start_explorer_at_folder(folder: str):
     explorer = desktop.wait_for_active_window(
         'name:Home or name:"File Explorer" or name:"Home - File Explorer"', timeout=2
     )
-    explorer.send_keys("{alt}d")
-    # TODO: provide API related to checking focus.
-    # desktop.wait_for_focused_control('class:TextBox name:"Address Bar"')
+    # Use Ctrl+L to focus the address bar
+    explorer.send_keys("{ctrl}l")
+    time.sleep(0.5)  # Brief wait for address bar to become active
+    # Clear any existing text and type the folder path
+    explorer.send_keys("{ctrl}a")  # Select all
+    time.sleep(0.2)
     explorer.send_keys(folder, send_enter=True)
+    # Wait for folder view to load and render files in the accessibility tree
+    time.sleep(3)
     return explorer
 
 

--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
@@ -1,5 +1,6 @@
 def _start_explorer_at_folder(folder: str):
     import time
+
     from robocorp import windows
 
     desktop = windows.desktop()
@@ -52,7 +53,7 @@ def test_copy_with_explorer(tmpdir):
         "(name:dummy_file.txt control:ListItemControl) or "
         "(name:dummy_file control:ListItemControl)",
         search_depth=12,
-        timeout=5
+        timeout=5,
     )
     items_view = explorer2.find('name:"Items View"', search_depth=12, timeout=5)
     desktop.drag_and_drop(report_html, items_view, hold_ctrl=True)

--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
@@ -6,8 +6,10 @@ def _start_explorer_at_folder(folder: str):
     desktop = windows.desktop()
     desktop.send_keys("{win}e")
     explorer = desktop.wait_for_active_window(
-        'name:Home or name:"File Explorer" or name:"Home - File Explorer"', timeout=2
+        'name:Home or name:"File Explorer" or name:"Home - File Explorer"',
+        timeout=2,
     )
+    time.sleep(2)  # Brief wait for address bar to become active
     # Use Ctrl+L to focus the address bar
     explorer.send_keys("{ctrl}l")
     time.sleep(0.5)  # Brief wait for address bar to become active
@@ -43,7 +45,9 @@ def test_copy_with_explorer(tmpdir):
     explorer1.set_window_pos(0, 0, desktop.width / 2, desktop.height)
 
     explorer2 = _start_explorer_at_folder(str(folder_b))
-    explorer2.set_window_pos(desktop.width / 2, 0, desktop.width / 2, desktop.height)
+    explorer2.set_window_pos(
+        desktop.width / 2, 0, desktop.width / 2, desktop.height
+    )
 
     # copying a file, dummy_file.txt, from source (File Explorer) window
     # into a target (File Explorer) Window
@@ -55,7 +59,9 @@ def test_copy_with_explorer(tmpdir):
         search_depth=12,
         timeout=5,
     )
-    items_view = explorer2.find('name:"Items View"', search_depth=12, timeout=5)
+    items_view = explorer2.find(
+        'name:"Items View"', search_depth=12, timeout=5
+    )
     desktop.drag_and_drop(report_html, items_view, hold_ctrl=True)
 
     wait_for_condition(dummy_to_create.exists)

--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
@@ -4,7 +4,7 @@ def _start_explorer_at_folder(folder: str):
     desktop = windows.desktop()
     desktop.send_keys("{win}e")
     explorer = desktop.wait_for_active_window(
-        'name:Home or name:"File Explorer"', timeout=2
+        'name:Home or name:"File Explorer" or name:"Home - File Explorer"', timeout=2
     )
     explorer.send_keys("{alt}d")
     # TODO: provide API related to checking focus.
@@ -43,9 +43,10 @@ def test_copy_with_explorer(tmpdir):
     report_html = explorer1.find(
         "(name:dummy_file.txt type:ListItem) or "
         "(name:dummy_file.txt control:ListItemControl) or "
-        "(name:dummy_file control:ListItemControl)"
+        "(name:dummy_file control:ListItemControl)",
+        search_depth=12
     )
-    items_view = explorer2.find('name:"Items View"')
+    items_view = explorer2.find('name:"Items View"', search_depth=12)
     desktop.drag_and_drop(report_html, items_view, hold_ctrl=True)
 
     wait_for_condition(dummy_to_create.exists)

--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
@@ -40,13 +40,15 @@ def test_copy_with_explorer(tmpdir):
 
     # copying a file, dummy_file.txt, from source (File Explorer) window
     # into a target (File Explorer) Window
+    # Use timeout to wait for folder view to populate with files
     report_html = explorer1.find(
         "(name:dummy_file.txt type:ListItem) or "
         "(name:dummy_file.txt control:ListItemControl) or "
         "(name:dummy_file control:ListItemControl)",
-        search_depth=12
+        search_depth=12,
+        timeout=5
     )
-    items_view = explorer2.find('name:"Items View"', search_depth=12)
+    items_view = explorer2.find('name:"Items View"', search_depth=12, timeout=5)
     desktop.drag_and_drop(report_html, items_view, hold_ctrl=True)
 
     wait_for_condition(dummy_to_create.exists)

--- a/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
+++ b/windows/tests/robocorp_windows_tests/test_robocorp_windows_explorer.py
@@ -9,7 +9,7 @@ def _start_explorer_at_folder(folder: str):
         'name:Home or name:"File Explorer" or name:"Home - File Explorer"',
         timeout=2,
     )
-    time.sleep(2)  # Brief wait for address bar to become active
+    time.sleep(3)  # Brief wait for address bar to become active
     # Use Ctrl+L to focus the address bar
     explorer.send_keys("{ctrl}l")
     time.sleep(0.5)  # Brief wait for address bar to become active
@@ -45,9 +45,7 @@ def test_copy_with_explorer(tmpdir):
     explorer1.set_window_pos(0, 0, desktop.width / 2, desktop.height)
 
     explorer2 = _start_explorer_at_folder(str(folder_b))
-    explorer2.set_window_pos(
-        desktop.width / 2, 0, desktop.width / 2, desktop.height
-    )
+    explorer2.set_window_pos(desktop.width / 2, 0, desktop.width / 2, desktop.height)
 
     # copying a file, dummy_file.txt, from source (File Explorer) window
     # into a target (File Explorer) Window
@@ -59,9 +57,7 @@ def test_copy_with_explorer(tmpdir):
         search_depth=12,
         timeout=5,
     )
-    items_view = explorer2.find(
-        'name:"Items View"', search_depth=12, timeout=5
-    )
+    items_view = explorer2.find('name:"Items View"', search_depth=12, timeout=5)
     desktop.drag_and_drop(report_html, items_view, hold_ctrl=True)
 
     wait_for_condition(dummy_to_create.exists)


### PR DESCRIPTION
## Summary

Updated test locators to handle UI structure changes in Chrome and Windows Explorer:

- **Chrome**: Increased `search_depth` from 9-10 to 12 to reach HTML form controls nested deeper in the accessibility tree
- **Chrome**: Changed text input locator from `name:"First name:"` to `id:fname` (Chrome now strips trailing colons from label text)  
- **Explorer**: Added `"Home - File Explorer"` window title variant for newer Windows versions
- **Explorer**: Increased `search_depth` to 12 for file item finding in the view hierarchy

## Test plan
- Windows package test suite should pass with these updated locators
- Tests validate Chrome browser automation and file Explorer drag-and-drop operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)