### PR TITLE
Bump CI actions and switch to pypa publish

### DIFF
--- a/.github/workflows/vault_release.yml
+++ b/.github/workflows/vault_release.yml
@@ -18,15 +18,15 @@ jobs:
 
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install poetry
       run: pipx install poetry
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
         cache: 'poetry'
 
     - name: Install project
@@ -38,7 +38,5 @@ jobs:
     - name: Build with poetry
       run: poetry build
 
-    - name: Upload to PyPI
-      run: |
-        poetry config pypi-token.pypi  ${{ secrets.PYPI_TOKEN_ROBOCORP_VAULT }}
-        poetry publish
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Update GitHub Actions workflow: use actions/checkout@v4 and actions/setup-python@v5 with Python 3.10 (was 3.9). Replace the manual poetry publish steps with pypa/gh-action-pypi-publish@release/v1 to simplify PyPI uploads and rely on the maintained publish action.