### PR TITLE
Add explicit permissions to all workflows

### DIFF
--- a/.github/workflows/_gen_workflows.py
+++ b/.github/workflows/_gen_workflows.py
@@ -138,6 +138,7 @@ class BaseTests:
         }
         self.jobs_build_in_jobs = {
             "runs-on": "${{ matrix.os }}",
+            "permissions": {"contents": "read"},
             "strategy": {
                 "fail-fast": False,
                 "matrix": self.matrix,

--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -26,6 +26,8 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/excel_tests.yml
+++ b/.github/workflows/excel_tests.yml
@@ -22,6 +22,8 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,6 +28,8 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/log_pytest_tests.yml
+++ b/.github/workflows/log_pytest_tests.yml
@@ -24,6 +24,8 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/log_tests.yml
+++ b/.github/workflows/log_tests.yml
@@ -24,6 +24,8 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/meta_outdated.yml
+++ b/.github/workflows/meta_outdated.yml
@@ -12,6 +12,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     strategy:
       fail-fast: true
 

--- a/.github/workflows/storage_tests.yml
+++ b/.github/workflows/storage_tests.yml
@@ -22,6 +22,8 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tasks_tests.yml
+++ b/.github/workflows/tasks_tests.yml
@@ -24,6 +24,8 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/vault_tests.yml
+++ b/.github/workflows/vault_tests.yml
@@ -22,6 +22,8 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -13,6 +13,9 @@ jobs:
   build:
     runs-on: windows-latest
 
+    permissions:
+      contents: read
+
     strategy:
       fail-fast: true
 

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -26,6 +26,8 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workitems_tests.yml
+++ b/.github/workflows/workitems_tests.yml
@@ -26,6 +26,8 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Set contents: read on all test and utility workflows, and split windows_release into build/deploy jobs so trusted publish (OIDC) works on the ubuntu deploy job.