### PR TITLE
fix(log): use ast.Constant so the rewriter works on Python 3.14

### DIFF
--- a/log/docs/CHANGELOG.md
+++ b/log/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fix `AttributeError: module 'ast' has no attribute 'Str'` on Python 3.14. `ast.Str` was
+  deprecated since 3.8 and removed in 3.14; the AST rewriter now uses `ast.Constant`
+  throughout. Also silences the related `DeprecationWarning` on 3.12/3.13.
+
 ## 3.1.3 - 2026-04-26
 
 - Fix 13 npm security vulnerabilities in log output React UI (dompurify, vite, lodash, flatted, picomatch, postcss, brace-expansion, tmp)

--- a/log/src/robocorp/log/_ast_utils.py
+++ b/log/src/robocorp/log/_ast_utils.py
@@ -676,8 +676,10 @@ class NodeFactory:
 
         return self._set_line_col(self.Attribute(ref, builtin_name))
 
-    def Str(self, s) -> ast.Str:
-        return self._set_line_col(ast.Str(s))
+    def Str(self, s) -> ast.Constant:
+        # `ast.Str` was removed in Python 3.14 (deprecated since 3.8); `ast.Constant`
+        # is the correct representation for a string literal on every supported version.
+        return self.Constant(s)
 
     def Constant(self, s) -> ast.Constant:
         return self._set_line_col(ast.Constant(s))

--- a/log/src/robocorp/log/_rewrite_ast_add_callbacks.py
+++ b/log/src/robocorp/log/_rewrite_ast_add_callbacks.py
@@ -1051,7 +1051,9 @@ def _handle_for_or_while(
             call.args.append(factory.IntConstant(for_step_id))
             call.args.append(
                 factory.Tuple(
-                    factory.Constant(f"{stmt_name_upper}_STEP"),  # FOR_STEP / WHILE_STEP
+                    factory.Constant(
+                        f"{stmt_name_upper}_STEP"
+                    ),  # FOR_STEP / WHILE_STEP
                     factory.NameLoad("__name__"),
                     factory.NameLoad("__file__"),
                     step_name_str,

--- a/log/src/robocorp/log/_rewrite_ast_add_callbacks.py
+++ b/log/src/robocorp/log/_rewrite_ast_add_callbacks.py
@@ -60,7 +60,7 @@ def _make_after_yield_expr(
             "after_yield",
             factory.NameLoad("__name__"),
             factory.NameLoad("__file__"),
-            factory.Str(f"{class_name}{function.name}"),
+            factory.Constant(f"{class_name}{function.name}"),
             factory.LineConstantAt(node_lineno),
         )
     )
@@ -75,7 +75,7 @@ def _make_before_yield_from_exprs(
             "before_yield_from",
             factory.NameLoad("__name__"),
             factory.NameLoad("__file__"),
-            factory.Str(f"{class_name}{function.name}"),
+            factory.Constant(f"{class_name}{function.name}"),
             factory.LineConstantAt(node_lineno),
         )
     )
@@ -90,7 +90,7 @@ def _make_after_yield_from_expr(
             "after_yield_from",
             factory.NameLoad("__name__"),
             factory.NameLoad("__file__"),
-            factory.Str(f"{class_name}{function.name}"),
+            factory.Constant(f"{class_name}{function.name}"),
             factory.LineConstantAt(node_lineno),
         )
     )
@@ -120,10 +120,10 @@ def _create_method_with_stmt(
     call = factory.Call(factory.NameLoadRewriteCallback(name))
 
     tup_elts = [
-        factory.Str(log_method_type),
+        factory.Constant(log_method_type),
         factory.NameLoad("__name__"),
         factory.NameLoad("__file__"),
-        factory.Str(f"{class_name}{function.name}"),
+        factory.Constant(f"{class_name}{function.name}"),
         factory.LineConstantAt(function.lineno),
     ]
 
@@ -133,15 +133,15 @@ def _create_method_with_stmt(
     for arg in function.args.args:
         if class_name and arg.arg == "self":
             continue
-        keys.append(factory.Str(arg.arg))
+        keys.append(factory.Constant(arg.arg))
         values.append(factory.NameLoad(arg.arg))
 
     if function.args.vararg:
-        keys.append(factory.Str(function.args.vararg.arg))
+        keys.append(factory.Constant(function.args.vararg.arg))
         values.append(factory.NameLoad(function.args.vararg.arg))
 
     if function.args.kwarg:
-        keys.append(factory.Str(function.args.kwarg.arg))
+        keys.append(factory.Constant(function.args.kwarg.arg))
         values.append(factory.NameLoad(function.args.kwarg.arg))
     dct.keys = keys
     dct.values = values
@@ -314,9 +314,10 @@ def rewrite_ast_add_callbacks(
         if (
             expect_docstring
             and isinstance(item, ast.Expr)
-            and isinstance(item.value, ast.Str)
+            and isinstance(item.value, ast.Constant)
+            and isinstance(item.value.value, str)
         ):
-            doc = item.value.s
+            doc = item.value.value
             if isinstance(doc, str) and is_rewrite_disabled(doc):
                 return
             expect_docstring = False
@@ -431,7 +432,7 @@ def _handle_return(
         call = factory.Call(factory.NameLoadRewriteCallback("method_return"))
         call.args.append(factory.NameLoad("__name__"))
         call.args.append(factory.NameLoad("__file__"))
-        call.args.append(factory.Str(f"{class_name}{function.name}"))
+        call.args.append(factory.Constant(f"{class_name}{function.name}"))
         call.args.append(factory.LineConstantAt(node.lineno))
 
         if node.value:
@@ -492,7 +493,7 @@ def _handle_continue_break(
             factory.Tuple(
                 factory.NameLoad("__name__"),
                 factory.NameLoad("__file__"),
-                factory.Str(f"{class_name}{function.name}"),
+                factory.Constant(f"{class_name}{function.name}"),
                 factory.LineConstantAt(node.lineno),
             )
         ]
@@ -595,10 +596,10 @@ def _handle_full_log_if(
             call.args.append(factory.IntConstant(if_id))
             call.args.append(
                 factory.Tuple(
-                    factory.Str(f"IF_SCOPE"),
+                    factory.Constant(f"IF_SCOPE"),
                     factory.NameLoad("__name__"),
                     factory.NameLoad("__file__"),
-                    factory.Str(f"{stmt_name} {ast.unparse(node.test)}"),
+                    factory.Constant(f"{stmt_name} {ast.unparse(node.test)}"),
                     factory.LineConstantAt(node.lineno),
                     targets,
                 )
@@ -624,10 +625,10 @@ def _handle_full_log_if(
             call.args.append(factory.IntConstant(else_id))
             call.args.append(
                 factory.Tuple(
-                    factory.Str(f"ELSE_SCOPE"),
+                    factory.Constant(f"ELSE_SCOPE"),
                     factory.NameLoad("__name__"),
                     factory.NameLoad("__file__"),
-                    factory.Str(f"else (to if {ast.unparse(node.test)})"),
+                    factory.Constant(f"else (to if {ast.unparse(node.test)})"),
                     factory.LineConstantAt(node.lineno),
                     targets,
                 )
@@ -678,7 +679,7 @@ def _handle_generator_if(
             call = factory.Call(factory.NameLoadRewriteCallback("method_if"))
             call.args.append(factory.NameLoad("__name__"))
             call.args.append(factory.NameLoad("__file__"))
-            call.args.append(factory.Str(f"{stmt_name} {ast.unparse(node.test)}"))
+            call.args.append(factory.Constant(f"{stmt_name} {ast.unparse(node.test)}"))
             call.args.append(factory.LineConstantAt(node.lineno))
 
             targets = _collect_names_used_as_node_or_none(factory, node.test)
@@ -694,7 +695,7 @@ def _handle_generator_if(
             call = factory.Call(factory.NameLoadRewriteCallback("method_else"))
             call.args.append(factory.NameLoad("__name__"))
             call.args.append(factory.NameLoad("__file__"))
-            call.args.append(factory.Str(f"else (to if {ast.unparse(node.test)})"))
+            call.args.append(factory.Constant(f"else (to if {ast.unparse(node.test)})"))
             call.args.append(factory.LineConstantAt(node.orelse[0].lineno))
             targets = _collect_names_used_as_node_or_none(factory, node.test)
             call.args.append(targets)
@@ -757,7 +758,7 @@ def _handle_before_assert(
             call = factory.Call(factory.NameLoadRewriteCallback("assert_failed"))
             call.args.append(factory.NameLoad("__name__"))
             call.args.append(factory.NameLoad("__file__"))
-            call.args.append(factory.Str(unparsed))
+            call.args.append(factory.Constant(unparsed))
             call.args.append(factory.LineConstantAt(node.lineno))
 
             new_if_node: ast.If = factory.If(factory.NotUnaryOp(node.test))
@@ -834,9 +835,9 @@ def _handle_assign(
                     "after_assign",
                     factory.NameLoad("__name__"),
                     factory.NameLoad("__file__"),
-                    factory.Str(f"{class_name}{function.name}"),
+                    factory.Constant(f"{class_name}{function.name}"),
                     factory.LineConstantAt(node.lineno),
-                    factory.Str(target.id),
+                    factory.Constant(target.id),
                     factory.NameLoad(target.id),
                 )
 
@@ -985,15 +986,15 @@ def _handle_for_or_while(
             iter_desc = ast.unparse(node.iter)
             collect_names_from_node = node.target
             target_desc = ast.unparse(node.target)
-            name_str = factory.Str(f"for {target_desc} in {iter_desc}")
-            step_name_str = factory.Str(f"Step: for {target_desc} in {iter_desc}")
+            name_str = factory.Constant(f"for {target_desc} in {iter_desc}")
+            step_name_str = factory.Constant(f"Step: for {target_desc} in {iter_desc}")
             stmt_name = "for"
 
         elif isinstance(node, ast.While):
             while_desc = ast.unparse(node.test)
             collect_names_from_node = node.test
-            name_str = factory.Str(f"while {while_desc}")
-            step_name_str = factory.Str(f"Step: while {while_desc}")
+            name_str = factory.Constant(f"while {while_desc}")
+            step_name_str = factory.Constant(f"Step: while {while_desc}")
             stmt_name = "while"
         else:
             raise RuntimeError(f"Unexpected node: {node}.")
@@ -1027,7 +1028,7 @@ def _handle_for_or_while(
         call.args.append(factory.IntConstant(for_id))
         call.args.append(
             factory.Tuple(
-                factory.Str(stmt_name_upper),  # FOR/WHILE
+                factory.Constant(stmt_name_upper),  # FOR/WHILE
                 factory.NameLoad("__name__"),
                 factory.NameLoad("__file__"),
                 name_str,
@@ -1050,7 +1051,7 @@ def _handle_for_or_while(
             call.args.append(factory.IntConstant(for_step_id))
             call.args.append(
                 factory.Tuple(
-                    factory.Str(f"{stmt_name_upper}_STEP"),  # FOR_STEP / WHILE_STEP
+                    factory.Constant(f"{stmt_name_upper}_STEP"),  # FOR_STEP / WHILE_STEP
                     factory.NameLoad("__name__"),
                     factory.NameLoad("__file__"),
                     step_name_str,
@@ -1112,7 +1113,7 @@ def _collect_names_used_as_node_or_none(
         target_load = factory.NameLoad(name_target.id)
         temp_targets.append(
             factory.Tuple(
-                factory.Str(replacement_dict.get(target_name, target_name)),
+                factory.Constant(replacement_dict.get(target_name, target_name)),
                 target_load,
             )
         )
@@ -1194,7 +1195,7 @@ def _handle_yield(
                             "before_yield",
                             factory.NameLoad("__name__"),
                             factory.NameLoad("__file__"),
-                            factory.Str(f"{class_name}{function.name}"),
+                            factory.Constant(f"{class_name}{function.name}"),
                             factory.LineConstantAt(node.lineno),
                             value_yielded,
                         )
@@ -1241,7 +1242,7 @@ def _handle_yield(
                             "before_yield",
                             factory.NameLoad("__name__"),
                             factory.NameLoad("__file__"),
-                            factory.Str(f"{class_name}{function.name}"),
+                            factory.Constant(f"{class_name}{function.name}"),
                             factory.LineConstantAt(node.lineno),
                             value_yielded,
                         )


### PR DESCRIPTION
Fixes #485.

## The bug

`ast.Str` was deprecated in Python 3.8, began emitting `DeprecationWarning` in 3.12, and was **removed in 3.14**. `robocorp-log` still used it, so it crashed during AST instrumentation:

```
File ".../robocorp/log/_rewrite_ast_add_callbacks.py", line 317, in rewrite_ast_add_callbacks
    and isinstance(item.value, ast.Str)
AttributeError: module 'ast' has no attribute 'Str'
```

I reproduced this end-to-end before fixing it — Python 3.14.4, `robocorp==3.1.2` (pulling `robocorp-tasks` 4.1.1 + `robocorp-log` 3.1.3), exit code 1. The identical setup on 3.13.12 runs clean.

One detail worth adding to the issue's analysis: the crash arrives via `_rewrite_importhook.py` while importing **`datetime`** from `_robo_logger.py`. The hook rewrites the AST of every module it loads and the docstring check runs on each one, so this dies on a stdlib import during logger setup — before `tasks.py` is even collected. No user-code workaround exists; only pinning Python below 3.14.

## The fix

- **`_ast_utils.py`** — `NodeFactory.Str()` now delegates to `Constant()`, which already sat directly beside it doing the correct thing.
- **`_rewrite_ast_add_callbacks.py`** — 28 `factory.Str(...)` call sites → `factory.Constant(...)`; the docstring check now tests `ast.Constant` *and* a `str` value, and reads `.value` instead of the removed `.s` accessor.

`ast.Constant` has been correct since 3.8, so there is no version gating. A repo-wide scan confirms no remaining use of `ast.Str`, `Num`, `Bytes`, `NameConstant` or `Ellipsis`, and no other package was affected.

## Test results

`log` package suite, all four combinations:

| Python | Fix | Result |
|---|---|---|
| 3.14.4 | **without** | 55 failed, 32 passed |
| 3.14.4 | **with** | **35 failed, 52 passed** |
| 3.13.12 | without | 35 failed, 52 passed |
| 3.13.12 | **with** | **35 failed, 52 passed** |

The fix turns **20 failures into passes on 3.14**, landing it at exact parity with 3.13, and is a **no-op on 3.13**. `test_rewrite_ast.py` — the 22 tests that directly exercise the rewriter — passes fully on 3.14.

**About the residual 35 failures: they are pre-existing and unrelated to this PR.** They are all `ImportError: cannot import name '_index_v3'` — the generated React log-viewer bundle, which is gitignored (`log/.gitignore:142`) and absent from a source checkout without a JS build. They appear identically on 3.13 and 3.14, with and without this change. Same class of problem as #481.

## Bonus

The 3.13 baseline emitted **163 `DeprecationWarning`s**, all `ast.Str is deprecated and will be removed in Python 3.14` from `_ast_utils.py:679-680`. Those are now gone.

## Two follow-ups I did not include here

Both are policy calls rather than part of this bug:

1. **`log/pyproject.toml` declares `python = "^3.10"`**, which resolves 3.14 as in-range — so pip installs happily into an environment that then crashes. The classifiers list only 3.10 and 3.11, so the metadata is already inconsistent with the constraint. Worth deciding whether to extend the classifiers or cap the constraint.
2. **`log_tests.yml` tests Python 3.10 only**, across all three OSes. That is why this reached a release uncaught, and why the next removal would too.

Also: `NodeFactory.Str()` is now unused everywhere in the repo. I kept it as a thin alias rather than deleting it, since it is a public-ish method on `NodeFactory` — happy to remove it if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)